### PR TITLE
Updates to add keyboard input for weight values

### DIFF
--- a/floor/controller/controller.py
+++ b/floor/controller/controller.py
@@ -32,7 +32,7 @@ class Controller(object):
 
         self.processor = module.create()
 
-    def set_driver(self, driver_name):
+    def set_driver(self, driver_name, driver_args):
 
         try:
             module = importlib.import_module("driver.{}".format(driver_name))
@@ -40,8 +40,7 @@ class Controller(object):
             print "Error: Driver '{}' does not exist or could not be loaded".format(driver_name)
             sys.exit(0)
 
-        self.driver = getattr(module, driver_name.title())()
-        self.driver.test_support()
+        self.driver = getattr(module, driver_name.title())(driver_args)
 
     def run(self):
         # Make sure the processor is limited to the bit depth of the driver

--- a/floor/driver/base.py
+++ b/floor/driver/base.py
@@ -4,9 +4,10 @@ class Base(object):
 
     MAX_LED_VALUE = 1023
 
-    def __init__(self):
+    def __init__(self, driver_args):
         self.weights = []
         self.leds = []
+        self.args = driver_args
 
     def get_weights(self):
         """

--- a/floor/driver/opc.py
+++ b/floor/driver/opc.py
@@ -1,13 +1,60 @@
 from base import Base
 from util import opc
+from util import getch
+import threading
+
+CHARS = []
+CHAR_MAP = {
+    '1': 0,
+    '2': 1,
+    '3': 2,
+    '4': 3,
+    '5': 4,
+    '6': 5,
+    '7': 6,
+    '8': 7,
+    'q': 8,
+    'w': 9,
+    'e': 10,
+    'r': 11,
+    't': 12,
+    'y': 13,
+    'u': 14,
+    'i': 15,
+    'a': 16,
+    's': 17,
+    'd': 18,
+    'f': 19,
+    'g': 20,
+    'h': 21,
+    'j': 22,
+    'k': 23,
+    'z': 24,
+    'x': 25,
+    'c': 26,
+    'v': 27,
+    'b': 28,
+    'n': 29,
+    'm': 30,
+    ',': 31,
+    '!': 32,
+    '@': 33,
+    '#': 34,
+    '$': 35,
+    '%': 36,
+    '^': 37,
+    '&': 38,
+    '*': 39,
+    '<': 63,
+}
 
 
 class Opc(Base):
 
     MAX_LED_VALUE = 256
 
-    def __init__(self):
-        super(Opc, self).__init__()
+    def __init__(self, args):
+        super(Opc, self).__init__(args)
         self.frame = 0
         self.ip_port = '127.0.0.1:7890'
         self.client = opc.Client(self.ip_port)
@@ -18,6 +65,21 @@ class Opc(Base):
             # can't connect, but keep running in case the server appears later
             print('    WARNING: could not connect to {}'.format(self.ip_port))
         print('')
+
+        if self.args['opc_input']:
+            self.read_thread = threading.Thread(target=self.read_chars_from_stdin)
+            self.read_thread.start()
+
+    @staticmethod
+    def read_chars_from_stdin():
+        global CHARS
+
+        while True:
+            char = getch.getch()
+            CHARS.append(char)
+
+            if ord(char) == 3:
+                exit(0)
 
     def send_data(self):
         """
@@ -30,3 +92,25 @@ class Opc(Base):
         :return:
         """
         pass
+
+    def get_weights(self):
+        """
+        :return:
+        """
+        weights = []
+        for i in range(0, 64):
+            weights.append(0)
+
+        if len(CHARS) > 0:
+            for char in CHARS.pop():
+                if char in CHAR_MAP:
+                    weights[CHAR_MAP[char]] = 1
+                elif char.lower() in CHAR_MAP:
+                    weights[CHAR_MAP[char.lower()]+32] = 1
+
+                if ord(char) == 3:
+                    print "Exiting ...\n"
+                    self.read_thread.join()
+                    exit(0)
+
+        return weights

--- a/floor/driver/raspberry.py
+++ b/floor/driver/raspberry.py
@@ -4,8 +4,8 @@ import importlib
 
 class Raspberry(Base):
 
-    def __init__(self):
-        super(Raspberry, self).__init__()
+    def __init__(self, args):
+        super(Raspberry, self).__init__(args)
 
         module = importlib.import_module("spidev")
 

--- a/floor/processor/pulsar.py
+++ b/floor/processor/pulsar.py
@@ -57,11 +57,34 @@ class Pulsar(Base):
 
         return sum
 
+    def handle_weight_input(self, weights):
+        # Weight values are either 0 or 1.  If 1 consider it a step and add a pixel
+        for i in range(0, 64):
+            if weights[i] > 0:
+                self.pixels[i] = (
+                    self.max_value * random.random(),
+                    self.max_value * random.random(),
+                    self.max_value * random.random())
+
+    def random_weight_input(self):
+        count = randint(1, 5)
+        for i in range(0, count):
+            # index: pick a random square for the source
+            index = randint(0, 63)
+            self.pixels[index] = (
+                self.max_value*random.random(),
+                self.max_value*random.random(),
+                self.max_value*random.random()
+            )
+
     def get_next_frame(self, weights):
         next_time = time.time()
 
         # reset_time could be beat driven
         reset_time = 1.2
+
+        # Read from weight input
+        self.handle_weight_input(weights)
 
         # whenever we hit the reset time, wipe the board and choose more sources
         if next_time - self.last_time > reset_time:
@@ -73,16 +96,8 @@ class Pulsar(Base):
                 for x in range(0, 8):
                     self.pixels.append((0, 0, 0))
 
-            # instead of picking random count and indexes, these could be the current highest weights
-            # count: make 1-4 sources for the new blossoms
-            count = randint(1, 5)
-            for i in range(0, count):
-                # index: pick a random square for the source
-                index = randint(0, 63)
-                self.pixels[index] = (
-                                    self.max_value*random.random(),
-                                    self.max_value*random.random(),
-                                    self.max_value*random.random())
+             # Uncomment to have random weight inputs
+#            self.random_weight_input()
 
         # after a certain amount of time, toggle wave direction and make it recede, but weakly
         elif (next_time - self.last_time) > (0.5*reset_time):

--- a/floor/run-show.py
+++ b/floor/run-show.py
@@ -14,10 +14,25 @@ parser.add_argument(
     default='raver_plaid',
     help='Sets the LED processor to generate each frame of light data'
 )
+parser.add_argument(
+    '--no-opc-input',
+    dest='opc_input',
+    action='store_false',
+    help='Turn off keyboard input handling'
+)
+parser.add_argument(
+    '--opc-input',
+    dest='opc_input',
+    action='store_true',
+    help='Turn on keyboard input handling'
+)
+parser.set_defaults(opc_input=True)
 args = parser.parse_args()
 
 show = Controller()
-show.set_driver(args.driver_name)
+show.set_driver(args.driver_name, {
+    "opc_input": args.opc_input
+})
 show.set_processor(args.processor_name)
 
 show.run()

--- a/floor/util/getch.py
+++ b/floor/util/getch.py
@@ -1,4 +1,3 @@
-import select
 
 
 def getch():

--- a/floor/util/getch.py
+++ b/floor/util/getch.py
@@ -1,0 +1,17 @@
+import select
+
+
+def getch():
+    import termios
+    import sys, tty
+
+    def _getch():
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return ch
+    return _getch()


### PR DESCRIPTION
Default is on.  Can be turned off via:
```bash
--no-opc-input
```
Keys for the floor squares are:
row 1: 1-9
row 2: q-i
row 3: a-k
row 4: z-,
row 5, 6, 7, 8: shift key with above

Also updated the pulsar processor to use weight values.  Note that because pulsar doesn't redraw until `reset_time` seconds have passed, so you need to time a keyboard press correctly, or hold  down the key.  A fix for this this might be to apply the pulsar effect individually to each foot press that came in rather than the entire floor at once.