### PR TITLE
Base processor API change; add processors to status API.

### DIFF
--- a/floor/config/playlist-default.json
+++ b/floor/config/playlist-default.json
@@ -84,6 +84,10 @@
     {
       "name": "raver_plaid",
       "duration": "60"
+    },
+    {
+      "name": "throbber",
+      "duration": "60"
     }
   ]
 }

--- a/floor/processor/README.md
+++ b/floor/processor/README.md
@@ -7,20 +7,15 @@
 from base import Base
 
 
-def create():
-    # Simply return a new instance of your class here
-    return YourPattern()
-
-
 class YourPattern(Base):
 
-    def __init__(self):
-        super(YourPattern, self).__init__()
+    def __init__(self, **kwargs):
+        super(YourPattern, self).__init__(**kwargs)
         # Set/initialize any state variables here
 
     def get_next_frame(self, weights):
         # This gets called once every 1/fps seconds
-    
+
         # Do something with list of weight values
 
         # Compute a list of RGB tuples, limit by self.max_value

--- a/floor/processor/animator.py
+++ b/floor/processor/animator.py
@@ -2,21 +2,14 @@ from base import Base
 import importlib
 
 
-def create(args=None):
-    return Animator(args)
-
-
 class Animator(Base):
 
     DEFAULT_ANIMATION = "gods_eye"
 
-    def __init__(self, args=None):
-        super(Animator, self).__init__()
+    def __init__(self, **kwargs):
+        super(Animator, self).__init__(**kwargs)
 
-        if "animation" in args:
-            animation = args["animation"]
-        else:
-            animation = self.DEFAULT_ANIMATION
+        animation = kwargs.get('animation', self.DEFAULT_ANIMATION)
 
         module = importlib.import_module("processor.animations.{}".format(animation))
         self.animation = module.anim()

--- a/floor/processor/base.py
+++ b/floor/processor/base.py
@@ -6,10 +6,9 @@ class Base(object):
     FLOOR_WIDTH = 8
     FLOOR_HEIGHT = 8
 
-    def __init__(self, args=dict):
+    def __init__(self, **kwargs):
         self.weights = []
         self.max_value = self.DEFAULT_MAX_VALUE
-        self.args = args
         self.bpm = None
         self.downbeat = None
 

--- a/floor/processor/color_wash.py
+++ b/floor/processor/color_wash.py
@@ -1,13 +1,9 @@
 from base import Base
 
 
-def create(args=None):
-    return ColorWash()
-
-
 class ColorWash(Base):
-    def __init__(self):
-        super(ColorWash, self).__init__()
+    def __init__(self, **kwargs):
+        super(ColorWash, self).__init__(**kwargs)
         self.red = 0
         self.green = 0
         self.blue = 0

--- a/floor/processor/electricity.py
+++ b/floor/processor/electricity.py
@@ -6,10 +6,6 @@ import logging
 logger = logging.getLogger('electricity')
 
 
-def create(args=None):
-    return Electricity()
-
-
 def dist(x1, y1, x2, y2):
     return math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
 
@@ -19,8 +15,8 @@ class Electricity(Base):
     DECAY_RATE = 0.8
     DECAY_THRESHOLD = 0.001
 
-    def __init__(self):
-        super(Electricity, self).__init__()
+    def __init__(self, **kwargs):
+        super(Electricity, self).__init__(**kwargs)
 
         self.arcs = {}
 

--- a/floor/processor/fishies.py
+++ b/floor/processor/fishies.py
@@ -4,13 +4,9 @@ import random
 from random import randint
 import time
 
-def create(args=None):
-    return Fishies()
-
-
 class Fishies(Base):
-    def __init__(self):
-        super(Fishies, self).__init__()
+    def __init__(self, **kwargs):
+        super(Fishies, self).__init__(**kwargs)
         self.pixels = []
         # self.palette = color.get_random_palette(self.max_value)
         self.palette = color.get_palette('rainbow_bunny', self.max_value)

--- a/floor/processor/flash_bang.py
+++ b/floor/processor/flash_bang.py
@@ -3,10 +3,6 @@ import random
 import math
 
 
-def create(args=None):
-    return FlashBang()
-
-
 class FlashBang(Base):
 
     # Random range for how long the main burst lasts
@@ -25,8 +21,8 @@ class FlashBang(Base):
     SPARKLE_PERCENT = 0.40
     SPARKLE_SPACING = 5
 
-    def __init__(self):
-        super(FlashBang, self).__init__()
+    def __init__(self, **kwargs):
+        super(FlashBang, self).__init__(**kwargs)
         self.burst_pixels = []
         self.sparkles = []
 

--- a/floor/processor/hyperspace.py
+++ b/floor/processor/hyperspace.py
@@ -5,16 +5,12 @@ import random
 import math
 
 
-def create(args=None):
-    return Hyperspace()
-
-
 class Hyperspace(Base):
 
     LIFETIME = 1.0
 
-    def __init__(self):
-        super(Hyperspace, self).__init__()
+    def __init__(self, **kwargs):
+        super(Hyperspace, self).__init__(**kwargs)
         self.pixels = []
         self.times = [0 for _ in range(64)]
         # self.palette = color.get_random_palette(self.max_value)

--- a/floor/processor/kaleidoscope.py
+++ b/floor/processor/kaleidoscope.py
@@ -4,16 +4,12 @@ import time
 import random
 
 
-def create(args=None):
-    return Kaleidoscope()
-
-
 class Kaleidoscope(Base):
 
     LIFETIME = 1.0
 
-    def __init__(self):
-        super(Kaleidoscope, self).__init__()
+    def __init__(self, **kwargs):
+        super(Kaleidoscope, self).__init__(**kwargs)
         self.active_px = []
         self.times = [0 for _ in range(64)]
         self.palette = color.get_random_palette(self.max_value)

--- a/floor/processor/land_mines.py
+++ b/floor/processor/land_mines.py
@@ -8,13 +8,9 @@ import math
 
 life_time = 4
 
-def create(args=None):
-    return LandMines()
-
-
 class LandMines(Base):
-    def __init__(self):
-        super(LandMines, self).__init__()
+    def __init__(self, **kwargs):
+        super(LandMines, self).__init__(**kwargs)
         self.pixels = []
         self.mines = []
         self.walkers = self.init_walkers()

--- a/floor/processor/life.py
+++ b/floor/processor/life.py
@@ -2,17 +2,12 @@ from base import Base
 import datetime
 
 
-def create(args=None):
-    # Simply return a new instance of your class here
-    return Life()
-
-
 class Life(Base):
 
     BPM = 94
 
-    def __init__(self):
-        super(Life, self).__init__()
+    def __init__(self, **kwargs):
+        super(Life, self).__init__(**kwargs)
 
         # used to track floor state
         self.active_px = self.init_frame(False)

--- a/floor/processor/message.py
+++ b/floor/processor/message.py
@@ -4,10 +4,6 @@ import colorsys
 import importlib
 
 
-def create(args=None):
-    return Message(args)
-
-
 class Message(Base):
 
     # The font to use
@@ -21,8 +17,8 @@ class Message(Base):
     # Default message to show if messages file is empty or missing
     DEFAULT_MESSAGE = "Burn baby burn, Disco Inferno"
 
-    def __init__(self, args=None):
-        super(Message, self).__init__()
+    def __init__(self, **kwargs):
+        super(Message, self).__init__(**kwargs)
 
         font_module = importlib.import_module("processor.fonts.{}".format(self.DEFAULT_FONT))
 
@@ -47,9 +43,9 @@ class Message(Base):
         # How fast to scroll in pixels per frame
         self.speed = 0.33
 
-        if "text" in args:
+        if "text" in kwargs:
             # Load a single message from the args
-            self.messages.append(args["text"])
+            self.messages.append(kwargs["text"])
         else:
             # Load a list of messages from the messages file
             self.load_messages()

--- a/floor/processor/pulsar.py
+++ b/floor/processor/pulsar.py
@@ -5,13 +5,9 @@ from random import randint
 import time
 
 
-def create(args=None):
-    return Pulsar()
-
-
 class Pulsar(Base):
-    def __init__(self):
-        super(Pulsar, self).__init__()
+    def __init__(self, **kwargs):
+        super(Pulsar, self).__init__(**kwargs)
         self.pixels = []
         self.wave_toggle = 1
         self.last_time = time.time()

--- a/floor/processor/random_decay.py
+++ b/floor/processor/random_decay.py
@@ -2,13 +2,9 @@ from base import Base
 import random
 
 
-def create(args=None):
-    return RandomDecay()
-
-
 class RandomDecay(Base):
-    def __init__(self):
-        super(RandomDecay, self).__init__()
+    def __init__(self, **kwargs):
+        super(RandomDecay, self).__init__(**kwargs)
         self.red = 0
         self.green = 0
         self.blue = 0

--- a/floor/processor/raver_plaid.py
+++ b/floor/processor/raver_plaid.py
@@ -5,14 +5,10 @@ import time
 import math
 
 
-def create(args=None):
-    return RaverPlaid()
-
-
 class RaverPlaid(Base):
 
-    def __init__(self):
-        super(RaverPlaid, self).__init__()
+    def __init__(self, **kwargs):
+        super(RaverPlaid, self).__init__(**kwargs)
 
         self.n_pixels = 64
 

--- a/floor/processor/stripes.py
+++ b/floor/processor/stripes.py
@@ -3,27 +3,21 @@ from util import color_utils
 import random
 
 
-def create(args=None):
-    if args is None:
-        args = {}
-    return Stripes(args)
-
-
 class Stripes(Base):
     DEFAULT_FADE_LENGTH = 100
 
     DEFAULT_MAX_SPEED = 1.0
     DEFAULT_MIN_SPEED = 0.2
 
-    def __init__(self, args):
-        super(Stripes, self).__init__()
+    def __init__(self, **kwargs):
+        super(Stripes, self).__init__(**kwargs)
         self.palette = color_utils.get_random_palette(self.max_value)
         self.gradient = [[] for _ in range(len(self.palette))]
         self.stripes = [None for _ in range(8)]
 
-        fade_length = args.get("length", self.DEFAULT_FADE_LENGTH)
-        self.max_speed = args.get("max_speed", self.DEFAULT_MAX_SPEED)
-        self.min_speed = args.get("min_speed", self.DEFAULT_MIN_SPEED)
+        fade_length = kwargs.get("length", self.DEFAULT_FADE_LENGTH)
+        self.max_speed = kwargs.get("max_speed", self.DEFAULT_MAX_SPEED)
+        self.min_speed = kwargs.get("min_speed", self.DEFAULT_MIN_SPEED)
 
         for idx, p in enumerate(self.palette):
             for n in range(fade_length, 1, -1):
@@ -107,4 +101,3 @@ class Stripe:
             if int(self.start) <= 0:
                 self.done = True
                 self.start = 0
-

--- a/floor/processor/test.py
+++ b/floor/processor/test.py
@@ -1,18 +1,13 @@
 from base import Base
 
 
-def create(args=None):
-    # Simply return a new instance of your class here
-    return Test()
-
-
 class Test(Base):
 
     SLOW_CYCLE = 30
     FAST_CYCLE = 2
 
-    def __init__(self):
-        super(Test, self).__init__()
+    def __init__(self, **kwargs):
+        super(Test, self).__init__(**kwargs)
 
         # helpful colors
         dark = (0, 0, 0)

--- a/floor/processor/throbber.py
+++ b/floor/processor/throbber.py
@@ -52,7 +52,3 @@ class Throbber(Base):
             draw_line(pixels, (0, 7), (7, 7), color)
 
         return pixels
-
-
-def create(args=None):
-    return Throbber()

--- a/floor/server/README.md
+++ b/floor/server/README.md
@@ -4,6 +4,62 @@ This is a simple HTTP service that exposes a public API and control web page to 
 
 ## API
 
+### `GET /api/status`
+
+Returns the current status.
+
+**Request Arguments**
+
+None.
+
+**Response**
+
+A structure consisting of:
+
+* `playlist` (object): The current playlist; see `GET /api/playlist`.
+* `tempo` (object): The current tempo; see `GET /api/tempo`.
+* `processors` (array): A list of available processor, each an object consisting of:
+  * `name` (string): The name of the processor.
+
+```json
+{
+  "playlist": {
+    "current_position": 1,
+    "millis_remaining": 2106,
+    "queue": [
+      {
+        "args": {
+          "animation": "Color train"
+        },
+        "duration": 5,
+        "name": "animator"
+      },
+      {
+        "args": {
+          "text": "Bleep bloop fazz!"
+        },
+        "duration": 5,
+        "name": "message"
+      },
+    ]
+  },
+  "processors": {
+    "animator": {
+      "name": "animator"
+    },
+    "message": {
+      "name": "message"
+    },
+    "pulsar": {
+      "name": "pulsar"
+    }
+  },
+  "tempo": {
+    "bpm": 120.0,
+    "downbeat_millis": 1500861666019
+  }
+}```
+
 ### `GET /api/playlist`
 
 Returns the current playlist.

--- a/floor/server/server.py
+++ b/floor/server/server.py
@@ -37,12 +37,21 @@ def view_tempo(bpm, downbeat):
         'downbeat_millis': int(downbeat * 1000)
     }
 
+def view_processors(processors):
+    ret = {}
+    for k, v in processors.iteritems():
+        ret[k] = {
+            'name': k,
+        }
+    return ret
+
 
 @app.route('/api/status', methods=['GET'])
 def api_status():
     result = {
         'playlist': view_playlist(app.controller.playlist),
         'tempo': view_tempo(app.controller.bpm, app.controller.downbeat),
+        'processors': view_processors(app.controller.processors),
     }
     return jsonify(result)
 

--- a/floor/server/templates/index.html
+++ b/floor/server/templates/index.html
@@ -334,7 +334,7 @@
     nudgeTempo(null, -100);
   }
 
-  function onDownbeatNudgedLeft() {
+  function onDownbeatNudgedRight() {
     nudgeTempo(null, 100);
   }
 


### PR DESCRIPTION
Chipping away at #25; this is a sort of uninteresting change, removing the `create()` factory function, so that `Controller` manages processor classes directly.

(To support a UI for options, I plan to add some sort of metadata declaring them on the processor classes themselves, which the server API can then introspect.)

Also adds available processors to the `/status` API.

cc @garthwebb 
cc @jbrecht 
