### PR TITLE
Implement midi callbacks and the midictrl annotation

### DIFF
--- a/floor/config/midi_maps/akai-apcmini.json
+++ b/floor/config/midi_maps/akai-apcmini.json
@@ -30,6 +30,34 @@
       "function": "set_brightness"
     },
     {
+      "command": ["control_mode_change", 48],
+      "function": "ranged_value_1"
+    },
+    {
+      "command": ["control_mode_change", 49],
+      "function": "ranged_value_2"
+    },
+    {
+      "command": ["control_mode_change", 50],
+      "function": "ranged_value_2"
+    },
+    {
+      "command": ["control_mode_change", 51],
+      "function": "ranged_value_2"
+    },
+    {
+      "command": ["control_mode_change", 52],
+      "function": "ranged_value_2"
+    },
+    {
+      "command": ["control_mode_change", 53],
+      "function": "ranged_value_2"
+    },
+    {
+      "command": ["control_mode_change", 54],
+      "function": "ranged_value_2"
+    },
+    {
       "command": ["note_on", "G#3"],
       "function": "foot_on_square_1"
     },

--- a/floor/config/midi_maps/akai-apcmini.json
+++ b/floor/config/midi_maps/akai-apcmini.json
@@ -39,23 +39,23 @@
     },
     {
       "command": ["control_mode_change", 50],
-      "function": "ranged_value_2"
+      "function": "ranged_value_3"
     },
     {
       "command": ["control_mode_change", 51],
-      "function": "ranged_value_2"
+      "function": "ranged_value_4"
     },
     {
       "command": ["control_mode_change", 52],
-      "function": "ranged_value_2"
+      "function": "ranged_value_5"
     },
     {
       "command": ["control_mode_change", 53],
-      "function": "ranged_value_2"
+      "function": "ranged_value_6"
     },
     {
       "command": ["control_mode_change", 54],
-      "function": "ranged_value_2"
+      "function": "ranged_value_7"
     },
     {
       "command": ["note_on", "G#3"],

--- a/floor/config/midi_maps/akai-apcmini.json
+++ b/floor/config/midi_maps/akai-apcmini.json
@@ -46,18 +46,6 @@
       "function": "ranged_value_4"
     },
     {
-      "command": ["control_mode_change", 52],
-      "function": "ranged_value_5"
-    },
-    {
-      "command": ["control_mode_change", 53],
-      "function": "ranged_value_6"
-    },
-    {
-      "command": ["control_mode_change", 54],
-      "function": "ranged_value_7"
-    },
-    {
       "command": ["note_on", "G#3"],
       "function": "foot_on_square_1"
     },

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -49,6 +49,15 @@ class Controller(object):
         self.fps = fps
         self.frame_seconds = 1.0/fps
 
+    def set_midi_bpm(self, context_value, value):
+        """Set a BPM based on a midi value
+
+        MIDI values range from 0 to 127.  Map this value to a range of BPMs from 90 to 170 BPM
+        """
+        bpm = 90
+        bpm += float(value) / 127.0 * 80
+        self.set_bpm(int(bpm))
+
     def set_bpm(self, bpm, downbeat=None):
         logger.info('Setting bpm to: {}'.format(bpm))
         self.bpm = float(bpm)
@@ -56,23 +65,27 @@ class Controller(object):
         if self.processor:
             self.processor.set_bpm(bpm, self.downbeat)
 
+    def scale_midi_brightness(self, context_value, value):
+        self.scale_brightness(value/127.0)
+
     def scale_brightness(self, factor):
         """Scale the default brightness from 0 to max for driver
 
         :param factor: a scaling factor from 0.0 to 1.0
         :return: none
         """
+        logger.info('Setting brightness to: {}%'.format(int(factor*100)))
         new_max = factor * self.max_led_value
         self.processor.set_max_value(new_max)
 
-    def square_weight_on(self, index):
+    def square_weight_on(self, index, *args):
         if index > 63 or index < 0:
             logger.error("Ignoring square_weight_on() value beyond bounds")
             return
         self.SYNTHETIC_WEIGHTS[index] = self.max_floor_value
         self.SYNTHETIC_WEIGHT_ACTIVE = True
 
-    def square_weight_off(self, index):
+    def square_weight_off(self, index, *args):
         if index > 63 or index < 0:
             logger.error("Ignoring square_weight_on() value beyond bounds")
             return

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -9,6 +9,7 @@ logger = logging.getLogger('controller')
 class Controller(object):
     DEFAULT_FPS = 24
     DEFAULT_BPM = 120.0
+    MAX_RANGED_VALUES = 4
 
     # Give outside controllers a chance to fake foot steps on the floor
     # Use the SYNTHETIC_WEIGHT_ACTIVE flag to determine if we need to spend
@@ -45,18 +46,11 @@ class Controller(object):
         # Maximum sensor value.
         self.max_floor_value = self.driver.get_max_floor_value()
 
+        self.ranged_values = [0] * self.MAX_RANGED_VALUES
+
     def set_fps(self, fps):
         self.fps = fps
         self.frame_seconds = 1.0/fps
-
-    def set_midi_bpm(self, context_value, value):
-        """Set a BPM based on a midi value
-
-        MIDI values range from 0 to 127.  Map this value to a range of BPMs from 90 to 170 BPM
-        """
-        bpm = 90
-        bpm += float(value) / 127.0 * 80
-        self.set_bpm(int(bpm))
 
     def set_bpm(self, bpm, downbeat=None):
         logger.info('Setting bpm to: {}'.format(bpm))
@@ -64,9 +58,6 @@ class Controller(object):
         self.downbeat = downbeat or time.time()
         if self.processor:
             self.processor.set_bpm(bpm, self.downbeat)
-
-    def scale_midi_brightness(self, context_value, value):
-        self.scale_brightness(value/127.0)
 
     def scale_brightness(self, factor):
         """Scale the default brightness from 0 to max for driver
@@ -78,14 +69,14 @@ class Controller(object):
         new_max = factor * self.max_led_value
         self.processor.set_max_value(new_max)
 
-    def square_weight_on(self, index, *args):
+    def square_weight_on(self, index):
         if index > 63 or index < 0:
             logger.error("Ignoring square_weight_on() value beyond bounds")
             return
         self.SYNTHETIC_WEIGHTS[index] = self.max_floor_value
         self.SYNTHETIC_WEIGHT_ACTIVE = True
 
-    def square_weight_off(self, index, *args):
+    def square_weight_off(self, index):
         if index > 63 or index < 0:
             logger.error("Ignoring square_weight_on() value beyond bounds")
             return
@@ -98,6 +89,16 @@ class Controller(object):
 
         # If nothing is set, there are no longer any synthetic weights active
         self.SYNTHETIC_WEIGHT_ACTIVE = False
+
+    def handle_ranged_value(self, control_number, control_value):
+        if control_number > self.MAX_RANGED_VALUES:
+            logger.warning('Ignoring MIDI control {}, greater than {}'.format(control_number, self.MAX_RANGED_VALUES))
+
+        # Capture state.
+        self.ranged_values[control_number] = control_value
+        # Update current processor.
+        if self.processor:
+            self.processor.on_ranged_value_change(control_number, control_value)
 
     def set_processor(self, processor_name, processor_args=dict):
         """Sets the active processor, which must already be loaded into

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -27,7 +27,7 @@ class MidiFunctions(object):
 
 
 MidiFunctions.add('playlist_next',
-                  callback=lambda controller, _: controller.playlist.next(1),
+                  callback=lambda controller, _: controller.playlist.advance(1),
                   help_text='Advance to the next item in the current playlist.')
 MidiFunctions.add('playlist_previous',
                   callback=lambda controller, _: controller.playlist.previous(1),

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -10,10 +10,10 @@ class MidiFunctions(object):
     """
     ALL_FUNCTIONS = {}
 
-    def __init__(self, name, context_value=None, help_text=''):
+    def __init__(self, name, callback, help_text=''):
         self.name = name
         self.help_text = help_text
-        self.context_value = context_value
+        self.callback = callback
 
     def __str__(self):
         return self.name
@@ -27,89 +27,94 @@ class MidiFunctions(object):
 
 
 MidiFunctions.add('playlist_next',
+                  callback=lambda controller, _: controller.playlist.next(1),
                   help_text='Advance to the next item in the current playlist.')
 MidiFunctions.add('playlist_previous',
+                  callback=lambda controller, _: controller.playlist.previous(1),
                   help_text='Go to previous item in the current playlist.')
-MidiFunctions.add('playlist_pause',
-                  help_text='Pause the current playlist.')
 MidiFunctions.add('playlist_play',
-                  help_text='Pause the current playlist.')
+                  callback=lambda controller, _: controller.playlist.play(),
+                  help_text='Play the current playlist.')
 MidiFunctions.add('playlist_stay',
+                  callback=lambda controller, _: controller.playlist.stay(),
                   help_text='Loop/repeat the current item in the playlist.')
 MidiFunctions.add('playlist_stop',
+                  callback=lambda controller, _: controller.playlist.stop_playlist(),
                   help_text='Stop playback of the current playlist.')
 MidiFunctions.add('playlist_goto_1',
-                  context_value=1,
+                  callback=lambda controller, _: controller.playlist.go_to(1),
                   help_text='Go to playlist position 1.')
 MidiFunctions.add('playlist_goto_2',
-                  context_value=2,
+                  callback=lambda controller, _: controller.playlist.go_to(2),
                   help_text='Go to playlist position 2.')
 MidiFunctions.add('playlist_goto_3',
-                  context_value=3,
+                  callback=lambda controller, _: controller.playlist.go_to(3),
                   help_text='Go to playlist position 3.')
 MidiFunctions.add('playlist_goto_4',
-                  context_value=4,
+                  callback=lambda controller, _: controller.playlist.go_to(4),
                   help_text='Go to playlist position 4.')
 MidiFunctions.add('playlist_goto_5',
-                  context_value=5,
+                  callback=lambda controller, _: controller.playlist.go_to(5),
                   help_text='Go to playlist position 5.')
 MidiFunctions.add('playlist_goto_6',
-                  context_value=6,
+                  callback=lambda controller, _: controller.playlist.go_to(6),
                   help_text='Go to playlist position 6.')
 MidiFunctions.add('playlist_goto_7',
-                  context_value=7,
+                  callback=lambda controller, _: controller.playlist.go_to(7),
                   help_text='Go to playlist position 7.')
 MidiFunctions.add('playlist_goto_8',
-                  context_value=8,
+                  callback=lambda controller, _: controller.playlist.go_to(8),
                   help_text='Go to playlist position 8.')
 MidiFunctions.add('playlist_goto_9',
-                  context_value=9,
+                  callback=lambda controller, _: controller.playlist.go_to(9),
                   help_text='Go to playlist position 9.')
 MidiFunctions.add('playlist_goto_10',
-                  context_value=10,
+                  callback=lambda controller, _: controller.playlist.go_to(10),
                   help_text='Go to playlist position 10.')
 MidiFunctions.add('playlist_goto_11',
-                  context_value=11,
+                  callback=lambda controller, _: controller.playlist.go_to(11),
                   help_text='Go to playlist position 11.')
 MidiFunctions.add('playlist_goto_12',
-                  context_value=12,
+                  callback=lambda controller, _: controller.playlist.go_to(12),
                   help_text='Go to playlist position 12.')
 MidiFunctions.add('playlist_goto_13',
-                  context_value=13,
+                  callback=lambda controller, _: controller.playlist.go_to(13),
                   help_text='Go to playlist position 13.')
 MidiFunctions.add('playlist_goto_14',
-                  context_value=14,
+                  callback=lambda controller, _: controller.playlist.go_to(14),
                   help_text='Go to playlist position 14.')
 MidiFunctions.add('playlist_goto_15',
-                  context_value=15,
+                  callback=lambda controller, _: controller.playlist.go_to(15),
                   help_text='Go to playlist position 15.')
 MidiFunctions.add('playlist_goto_16',
-                  context_value=16,
+                  callback=lambda controller, _: controller.playlist.go_to(16),
                   help_text='Go to playlist position 16.')
 MidiFunctions.add('set_bpm',
+                  callback=lambda controller, value: controller.set_bpm(90 + 80 * (value/127.0)),
                   help_text='Set the global bpm based on note velocity or controller value.')
 MidiFunctions.add('set_brightness',
+                  callback=lambda controller, value: controller.scale_brightness(value/127.0),
                   help_text='Adjust the max brightness of the floor')
 
 # Add a number of ranged values, likely faders or knobs, that can be used within processor code
 # to tweak parameters.
-for idx in range(1, 16):
-    MidiFunctions.add('ranged_value_{}'.format(idx),
-                      context_value=idx,
+for idx in range(0, 4):
+    MidiFunctions.add('ranged_value_{}'.format(idx+1),
+                      callback=lambda controller, value, i=idx: controller.handle_ranged_value(i, value),
                       help_text='A generic ranged value for adjusting processor parameters')
 
 # Setup methods for floor foot presses
 for idx in range(1, 65):
     MidiFunctions.add(
         'foot_on_square_{}'.format(idx),
-        context_value=idx,
+        callback=lambda controller, _, i=idx: controller.square_weight_on(i),
         help_text='Send a foot step for square {}'.format(idx)
     )
 
-# Setup methods for floor foot presses
+# Setup methods for floor foot releases
 for idx in range(1, 65):
     MidiFunctions.add(
         'foot_off_square_{}'.format(idx),
-        context_value=idx,
+        callback=lambda controller, _, i=idx: controller.square_weight_off(i),
         help_text='Release a foot step for square {}'.format(idx)
     )

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -10,9 +10,10 @@ class MidiFunctions(object):
     """
     ALL_FUNCTIONS = {}
 
-    def __init__(self, name, help_text=''):
+    def __init__(self, name, context_value=None, help_text=''):
         self.name = name
         self.help_text = help_text
+        self.context_value = context_value
 
     def __str__(self):
         return self.name
@@ -38,46 +39,70 @@ MidiFunctions.add('playlist_stay',
 MidiFunctions.add('playlist_stop',
                   help_text='Stop playback of the current playlist.')
 MidiFunctions.add('playlist_goto_1',
+                  context_value=1,
                   help_text='Go to playlist position 1.')
 MidiFunctions.add('playlist_goto_2',
+                  context_value=2,
                   help_text='Go to playlist position 2.')
 MidiFunctions.add('playlist_goto_3',
+                  context_value=3,
                   help_text='Go to playlist position 3.')
 MidiFunctions.add('playlist_goto_4',
+                  context_value=4,
                   help_text='Go to playlist position 4.')
 MidiFunctions.add('playlist_goto_5',
+                  context_value=5,
                   help_text='Go to playlist position 5.')
 MidiFunctions.add('playlist_goto_6',
+                  context_value=6,
                   help_text='Go to playlist position 6.')
 MidiFunctions.add('playlist_goto_7',
+                  context_value=7,
                   help_text='Go to playlist position 7.')
 MidiFunctions.add('playlist_goto_8',
+                  context_value=8,
                   help_text='Go to playlist position 8.')
 MidiFunctions.add('playlist_goto_9',
+                  context_value=9,
                   help_text='Go to playlist position 9.')
 MidiFunctions.add('playlist_goto_10',
+                  context_value=10,
                   help_text='Go to playlist position 10.')
 MidiFunctions.add('playlist_goto_11',
+                  context_value=11,
                   help_text='Go to playlist position 11.')
 MidiFunctions.add('playlist_goto_12',
+                  context_value=12,
                   help_text='Go to playlist position 12.')
 MidiFunctions.add('playlist_goto_13',
+                  context_value=13,
                   help_text='Go to playlist position 13.')
 MidiFunctions.add('playlist_goto_14',
+                  context_value=14,
                   help_text='Go to playlist position 14.')
 MidiFunctions.add('playlist_goto_15',
+                  context_value=15,
                   help_text='Go to playlist position 15.')
 MidiFunctions.add('playlist_goto_16',
+                  context_value=16,
                   help_text='Go to playlist position 16.')
 MidiFunctions.add('set_bpm',
                   help_text='Set the global bpm based on note velocity or controller value.')
 MidiFunctions.add('set_brightness',
                   help_text='Adjust the max brightness of the floor')
 
+# Add a number of ranged values, likely faders or knobs, that can be used within processor code
+# to tweak parameters.
+for idx in range(1, 16):
+    MidiFunctions.add('ranged_value_{}'.format(idx),
+                      context_value=idx,
+                      help_text='A generic ranged value for adjusting processor parameters')
+
 # Setup methods for floor foot presses
 for idx in range(1, 65):
     MidiFunctions.add(
         'foot_on_square_{}'.format(idx),
+        context_value=idx,
         help_text='Send a foot step for square {}'.format(idx)
     )
 
@@ -85,5 +110,6 @@ for idx in range(1, 65):
 for idx in range(1, 65):
     MidiFunctions.add(
         'foot_off_square_{}'.format(idx),
+        context_value=idx,
         help_text='Release a foot step for square {}'.format(idx)
     )

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -27,10 +27,10 @@ class MidiFunctions(object):
 
 
 MidiFunctions.add('playlist_next',
-                  callback=lambda controller, _: controller.playlist.advance(1),
+                  callback=lambda controller, _: controller.playlist.advance(),
                   help_text='Advance to the next item in the current playlist.')
 MidiFunctions.add('playlist_previous',
-                  callback=lambda controller, _: controller.playlist.previous(1),
+                  callback=lambda controller, _: controller.playlist.previous(),
                   help_text='Go to previous item in the current playlist.')
 MidiFunctions.add('playlist_play',
                   callback=lambda controller, _: controller.playlist.play(),

--- a/floor/floor/controller/midi/manager.py
+++ b/floor/floor/controller/midi/manager.py
@@ -44,8 +44,6 @@ class MidiManager(object):
         self.logger.info('Midi enabled, port={}'.format(port))
         self.default_midi_mapping = default_midi_mapping or MidiMapping(name='default')
 
-        self.register_midi_functions()
-
     def load_default_midi_mapping(self, mapping_dir, map_name):
         """Can be used to load a mapping JSON file to use as the default MIDI mapping"""
 
@@ -87,45 +85,6 @@ class MidiManager(object):
         self.logger.info('Peer disconnected: {}'.format(peer))
         del self.midi_peers_to_mappings[peer.ssrc]
 
-    @classmethod
-    def register_global_callback(cls, function, callback):
-        if function not in cls.GLOBAL_CALLBACKS:
-            cls.GLOBAL_CALLBACKS[function] = []
-        cls.GLOBAL_CALLBACKS[function].append(callback)
-
-    @classmethod
-    def register_processor_callback(cls, processor, function, callback):
-        if processor not in cls.PROCESSOR_CALLBACKS:
-            cls.PROCESSOR_CALLBACKS[processor] = {}
-        if function not in cls.PROCESSOR_CALLBACKS[processor]:
-            cls.PROCESSOR_CALLBACKS[processor][function] = []
-
-        cls.PROCESSOR_CALLBACKS[processor][function].append(callback)
-
-    def handle_global_callback(self, function, value):
-        if function not in self.GLOBAL_CALLBACKS:
-            return
-
-        context_value = function.context_value
-        callbacks = self.GLOBAL_CALLBACKS[function]
-        for fn in callbacks:
-            fn(context_value, value)
-
-    def handle_processor_callback(self, function, value):
-        processor_class = self.controller.processor.__class__
-        processor_name = processor_class.__name__
-
-        if processor_name not in self.PROCESSOR_CALLBACKS:
-            return
-
-        if function not in self.PROCESSOR_CALLBACKS[processor_name]:
-            return
-
-        context_value = function.context_value
-        callbacks = self.PROCESSOR_CALLBACKS[processor_name][function]
-        for fn in callbacks:
-            fn(processor_class, context_value, value)
-
     def on_midi_commands(self, peer, commands):
         commands = map(MidiManager.command_to_tuple, commands)
         mapping = self.get_midi_mapping(peer)
@@ -138,44 +97,7 @@ class MidiManager(object):
 
             value = command[2]
 
-            self.handle_global_callback(func, value)
-            self.handle_processor_callback(func, value)
-
-    def register_midi_functions(self):
-        controller = self.controller
-        playlist = controller.playlist
-
-        self.register_global_callback(MidiFunctions.playlist_next, playlist.advance)
-        self.register_global_callback(MidiFunctions.playlist_previous, playlist.previous)
-        self.register_global_callback(MidiFunctions.playlist_stop, playlist.stop_playlist)
-        self.register_global_callback(MidiFunctions.playlist_play, playlist.start_playlist)
-        self.register_global_callback(MidiFunctions.playlist_stay, playlist.stay)
-
-        for idx in range(1, 17):
-            func_name = 'playlist_goto_{}'.format(idx)
-            func = MidiFunctions.ALL_FUNCTIONS[func_name]
-            if not func:
-                continue
-
-            self.register_global_callback(func, playlist.go_to)
-
-        self.register_global_callback(MidiFunctions.set_bpm, controller.set_midi_bpm)
-        self.register_global_callback(MidiFunctions.set_brightness, controller.scale_midi_brightness)
-
-        for idx in range(1, 65):
-            func_name = 'foot_on_square_{}'.format(idx)
-            func = MidiFunctions.ALL_FUNCTIONS[func_name]
-            if not func:
-                continue
-
-            self.register_global_callback(func, controller.square_weight_on)
-
-            func_name = 'foot_off_square_{}'.format(idx)
-            func = MidiFunctions.ALL_FUNCTIONS[func_name]
-            if not func:
-                continue
-
-            self.register_global_callback(func, controller.square_weight_off)
+            func.callback(self.controller, value)
 
     def run_server(self):
         thr = threading.Thread(target=self.midi_server.serve_forever)

--- a/floor/floor/controller/midi/manager.py
+++ b/floor/floor/controller/midi/manager.py
@@ -106,7 +106,7 @@ class MidiManager(object):
         if function not in self.GLOBAL_CALLBACKS:
             return
 
-        context_value = function.value
+        context_value = function.context_value
         callbacks = self.GLOBAL_CALLBACKS[function]
         for fn in callbacks:
             fn(context_value, value)

--- a/floor/floor/controller/midi/manager.py
+++ b/floor/floor/controller/midi/manager.py
@@ -28,7 +28,6 @@ class MidiHandler(pymidi_server.Handler):
 
 
 class MidiManager(object):
-
     """Binds a pymidi server to the dance floor controller."""
     def __init__(self, port, controller, default_midi_mapping=None):
         self.controller = controller

--- a/floor/floor/controller/midi/manager.py
+++ b/floor/floor/controller/midi/manager.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import re
 import threading
 
 from pymidi import server as pymidi_server
 
-from .functions import MidiFunctions
 from .constants import COMMAND_NOTE_ON, COMMAND_NOTE_OFF, MIDI_NOTE_NAMES, COMMAND_CONTROL_MODE_CHANGE
 from .mapping import MidiMapping
 
@@ -30,8 +28,6 @@ class MidiHandler(pymidi_server.Handler):
 
 
 class MidiManager(object):
-    GLOBAL_CALLBACKS = {}  # type: {[]}
-    PROCESSOR_CALLBACKS = {}  # type: {{[]}}
 
     """Binds a pymidi server to the dance floor controller."""
     def __init__(self, port, controller, default_midi_mapping=None):

--- a/floor/floor/controller/midi_test.py
+++ b/floor/floor/controller/midi_test.py
@@ -51,12 +51,6 @@ class MidiManagerTestCase(TestCase):
     def setUp(self):
         self.controller = mock.Mock()
         self.controller.processor = mock.Mock()
-        self.controller.processor.handle_midi_command = mock.Mock()
-        MidiManager.register_processor_callback(
-            self.controller.processor.__class__.__name__,
-            MidiFunctions.ranged_value_2,
-            self.controller.processor.handle_midi_command
-        )
 
         self.mapping = DEMO_MAPPING
         self.manager = MidiManager(
@@ -100,11 +94,11 @@ class MidiManagerTestCase(TestCase):
         self.inject_control_mode_change(21, 127)
         self.assertEqual(1, self.controller.playlist.stop_playlist.call_count)
 
-        self.assertEqual(0, self.controller.processor.handle_midi_command.call_count)
+        self.assertEqual(0, self.controller.handle_ranged_value.call_count)
         self.inject_control_mode_change(48, 99)
-        self.assertEqual(1, self.controller.processor.handle_midi_command.call_count)
-        self.controller.processor.handle_midi_command.assert_has_calls([
-            mock.call(self.controller.processor.__class__, 2, 99),
+        self.assertEqual(1, self.controller.handle_ranged_value.call_count)
+        self.controller.handle_ranged_value.assert_has_calls([
+            mock.call(1, 99),
         ])
 
     def test_note_name_translation(self):

--- a/floor/floor/controller/midi_test.py
+++ b/floor/floor/controller/midi_test.py
@@ -16,7 +16,9 @@ import mock
 DEMO_MAPPING = MidiMapping(name='demo', mappings={
     (COMMAND_NOTE_ON, 'C3'): MidiFunctions.playlist_next,
     (COMMAND_NOTE_ON, 'C4'): MidiFunctions.playlist_previous,
+    (COMMAND_NOTE_ON, 'C#-1', 127): MidiFunctions.playlist_stay,
     (COMMAND_CONTROL_MODE_CHANGE, 21, 127): MidiFunctions.playlist_stop,
+    (COMMAND_CONTROL_MODE_CHANGE, 48): MidiFunctions.ranged_value_2,
 })
 
 
@@ -50,6 +52,12 @@ class MidiManagerTestCase(TestCase):
         self.controller = mock.Mock()
         self.controller.processor = mock.Mock()
         self.controller.processor.handle_midi_command = mock.Mock()
+        MidiManager.register_processor_callback(
+            self.controller.processor.__class__.__name__,
+            MidiFunctions.ranged_value_2,
+            self.controller.processor.handle_midi_command
+        )
+
         self.mapping = DEMO_MAPPING
         self.manager = MidiManager(
             port=1234,
@@ -92,17 +100,14 @@ class MidiManagerTestCase(TestCase):
         self.inject_control_mode_change(21, 127)
         self.assertEqual(1, self.controller.playlist.stop_playlist.call_count)
 
-        self.assertEqual(4, self.controller.processor.handle_midi_command.call_count)
+        self.assertEqual(0, self.controller.processor.handle_midi_command.call_count)
+        self.inject_control_mode_change(48, 99)
+        self.assertEqual(1, self.controller.processor.handle_midi_command.call_count)
         self.controller.processor.handle_midi_command.assert_has_calls([
-            mock.call(('note_on', 'C3', 127)),
-            mock.call(('note_on', 'C4', 55)),
-            mock.call(('control_mode_change', 21, 11)),
-            mock.call(('control_mode_change', 21, 127)),
+            mock.call(self.controller.processor.__class__, 2, 99),
         ])
 
     def test_note_name_translation(self):
+        self.assertEqual(0, self.controller.playlist.stay.call_count)
         self.inject_note_on('Csn1', 127)
-        self.assertEqual(1, self.controller.processor.handle_midi_command.call_count)
-        self.controller.processor.handle_midi_command.assert_called_once_with(
-            ('note_on', 'C#-1', 127)
-        )
+        self.assertEqual(1, self.controller.playlist.stay.call_count)

--- a/floor/floor/controller/playlist.py
+++ b/floor/floor/controller/playlist.py
@@ -59,7 +59,7 @@ class Playlist(object):
     def is_running(self):
         return self.running
 
-    def stop_playlist(self, *args):
+    def stop_playlist(self):
         current = self.queue[self.position]
 
         # Save time remaining
@@ -71,7 +71,7 @@ class Playlist(object):
 
         self.running = False
 
-    def start_playlist(self, *args):
+    def start_playlist(self):
         current = self.queue[self.position]
 
         if current['remaining_duration'] is not None:
@@ -107,7 +107,7 @@ class Playlist(object):
 
         return self.queue[self.position]
 
-    def advance(self, *args):
+    def advance(self):
         """Go to the next playlist item."""
         if self.position is None:
             position = 0
@@ -115,7 +115,7 @@ class Playlist(object):
             position = (self.position + 1) % len(self.queue)
         self.go_to(position)
 
-    def previous(self, *args):
+    def previous(self):
         """Go to the previous playlist item."""
         if self.position is None:
             position = 0
@@ -123,7 +123,7 @@ class Playlist(object):
             position = (self.position - 1) % len(self.queue)
         self.go_to(position)
 
-    def go_to(self, position, *args):
+    def go_to(self, position):
         """Go to a specific playlist item."""
         if not self.is_running():
             return
@@ -162,5 +162,5 @@ class Playlist(object):
             # Position was ahead of current.
             pass
 
-    def stay(self, *args):
+    def stay(self):
         self.next_advance = None

--- a/floor/floor/controller/playlist.py
+++ b/floor/floor/controller/playlist.py
@@ -59,7 +59,7 @@ class Playlist(object):
     def is_running(self):
         return self.running
 
-    def stop_playlist(self):
+    def stop_playlist(self, *args):
         current = self.queue[self.position]
 
         # Save time remaining
@@ -71,7 +71,7 @@ class Playlist(object):
 
         self.running = False
 
-    def start_playlist(self):
+    def start_playlist(self, *args):
         current = self.queue[self.position]
 
         if current['remaining_duration'] is not None:
@@ -107,7 +107,7 @@ class Playlist(object):
 
         return self.queue[self.position]
 
-    def advance(self):
+    def advance(self, *args):
         """Go to the next playlist item."""
         if self.position is None:
             position = 0
@@ -115,7 +115,7 @@ class Playlist(object):
             position = (self.position + 1) % len(self.queue)
         self.go_to(position)
 
-    def previous(self):
+    def previous(self, *args):
         """Go to the previous playlist item."""
         if self.position is None:
             position = 0
@@ -123,7 +123,7 @@ class Playlist(object):
             position = (self.position - 1) % len(self.queue)
         self.go_to(position)
 
-    def go_to(self, position):
+    def go_to(self, position, *args):
         """Go to a specific playlist item."""
         if not self.is_running():
             return
@@ -162,5 +162,5 @@ class Playlist(object):
             # Position was ahead of current.
             pass
 
-    def stay(self):
+    def stay(self, *args):
         self.next_advance = None

--- a/floor/floor/processor/base.py
+++ b/floor/floor/processor/base.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
+
 
 class ProcessorRegistry(type):
     """Python metaclass which automatically adds the class to `ALL_PROCESSORS`."""
@@ -15,6 +17,7 @@ class ProcessorRegistry(type):
             raise ValueError('Multiple processors with name "{}" declared'.format(class_name))
         cls.ALL_PROCESSORS[class_name] = new_class
         return new_class
+
 
 class RenderContext:
     """An object that a `Controller` will pass to `Processor.get_next_frame`.
@@ -32,16 +35,79 @@ class RenderContext:
 class Base(object):
     __metaclass__ = ProcessorRegistry
 
+    CONTROLS = []
+
     DEFAULT_MAX_VALUE = 1024
     FLOOR_WIDTH = 8
     FLOOR_HEIGHT = 8
     PIXELS_ALL_OFF = [[0 for _ in range(3)] for _ in range(64)]
 
     def __init__(self, **kwargs):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
         self.weights = []
         self.max_value = self.DEFAULT_MAX_VALUE
         self.bpm = None
         self.downbeat = None
+        self.ranged_values = []
+
+        self._controls = []
+        self.init_controls()
+
+    def init_controls(self):
+        for item in self.CONTROLS:
+            name = item['name']
+            if name in self.__dict__:
+                raise AttributeError('Proposed control name {} already exists in class'.format(name))
+
+            if 'range' in item:
+                self.add_range_control(name, item)
+            elif 'scale' in item:
+                self.add_scale_control(name, item)
+            else:
+                self.add_absolute_control(name, item)
+
+    def add_absolute_control(self, name, item):
+        if 'default' in item:
+            default = item['default']
+        else:
+            default = 0
+
+        self._controls.append({
+            'name': name,
+            'handler': lambda input_value: input_value
+        })
+        self.__dict__[name] = default
+
+    def add_scale_control(self, name, item):
+        scale = item['scale']
+        item['range'] = [0.0, scale]
+        return self.add_range_control(name, item)
+
+    def add_range_control(self, name, item):
+        r = item['range']
+        handler = self.get_range_handler(0, 127, r[0], r[1])
+
+        if 'default' in item:
+            default = item['default']
+        else:
+            default = r[0]
+
+        self._controls.append({
+            'name': name,
+            'handler': handler
+        })
+        self.__dict__[name] = default
+
+    @classmethod
+    def get_range_handler(cls, input_min, input_max, output_min, output_max):
+        input_delta = input_max - input_min
+        output_delta = output_max - output_min
+
+        def range_handler(input_value):
+            return output_min + (float(input_value - input_min) / input_delta) * output_delta
+
+        return range_handler
 
     # accept (x,y) tuple reflecting a coordinate
     # return the array index suitable for use in weights or pixels arrays
@@ -78,3 +144,14 @@ class Base(object):
         assert downbeat is not None
         self.bpm = bpm
         self.downbeat = downbeat
+
+    def on_ranged_value_change(self, num, val):
+        if num >= len(self._controls):
+            return
+
+        control = self._controls[num]
+        name = control['name']
+        handler = control['handler']
+        output_value = handler(val)
+        self.__dict__[name] = output_value
+        self.logger.info("Set control {} to {}".format(name, output_value))

--- a/floor/floor/processor/heat_step.py
+++ b/floor/floor/processor/heat_step.py
@@ -1,9 +1,4 @@
-import logging
-
 from base import Base
-from floor.controller import midi
-
-logger = logging.getLogger('simple_step')
 
 # Matrix of distances so we don't have to calculate them.  Distances
 # are from the corner at 0, 0.  Can be reflected over x or y to give distance
@@ -22,70 +17,37 @@ DISTANCE = [
 
 class HeatStep(Base):
 
-    # Good single steps: 3.5, 0.75
-    # Good group steps 20.5, 0.95
-    HEAT_RANGE = [3.5, 30.0]
-    COOL_RANGE = [0.75, 0.95]
+    CONTROLS = [
+        {
+            'name': 'HUE',
+            'scale': 1.0,
+            'default': 1.0
+        },
+        {
+            'name': 'SAT',
+            'scale': 1.0,
+            'default': 1.0
+        },
+        # Good single steps for heat, cool: 3.5, 0.75
+        # Good group steps for heat, cool: 20.5, 0.95
+        {
+            'name': 'HEAT',  # How much foot steps "heat" up the floor
+            'range': [30.0, 3.5],
+            'default': 20.0
+        },
+        {
+            'name': 'COOL',  # How fast the floor "cools" over time
+            'range': [0.95, 0.75],
+            'default': 0.95
+        }
+    ]
 
     def __init__(self, **kwargs):
         super(HeatStep, self).__init__(**kwargs)
         self.pixels = self.zeroed_pixel_array()
 
-        self.hue = 1.0
         self.secondary_hue = 0.5
-        self.saturation = 1.0
         self.value = 1.0
-
-        self.heat_factor = 20.5
-        self.cool_factor = 0.95
-        self.heat_delta = self.HEAT_RANGE[1] - self.HEAT_RANGE[0]
-        self.cool_delta = self.COOL_RANGE[1] - self.COOL_RANGE[0]
-
-    def handle_midi_command(self, command):
-        if command[0] == midi.COMMAND_CONTROL_MODE_CHANGE:
-            num = command[2]
-            if command[1] == 48:
-                self.adjust_hue(num)
-            elif command[1] == 49:
-                self.adjust_saturation(num)
-            elif command[1] == 50:
-                self.adjust_heating(num)
-            elif command[1] == 51:
-                self.adjust_cooling(num)
-
-    def adjust_hue(self, num):
-        self.hue = num / 127.0
-
-        # Set the secondary hue to be 180 deg off the primary hue
-        self.secondary_hue = self.hue + 0.5
-        if self.secondary_hue > 1.0:
-            self.secondary_hue -= 1.0
-
-        logger.info("Set primary hue to {}/127".format(num))
-
-    def adjust_saturation(self, num):
-        self.saturation = num / 127.0
-        logger.info("Set saturation to {}/127".format(num))
-
-    def adjust_heating(self, num):
-        """Adjust the heating within the range given by HEAT_RANGE
-
-        Higher numbers actually mean lower "heating" since this factor is used as a
-        factor dividing the max value.  So, we do 1 - num/127 to make sure the sliders
-        act as "more heating" when pushed up.
-        """
-        self.heat_factor = self.HEAT_RANGE[0] + (1-(num/127.0))*self.heat_delta
-        logger.info("Set heating to {0:.2f}".format(self.heat_factor))
-
-    def adjust_cooling(self, num):
-        """Adjust the cooling within the range given by COOL_RANGE
-
-        Higher numbers actually mean slower "cooling" since this factor between 0.0 and 1.0
-        is used as a percentage "heat" lost.  So, we do 1 - num/127 to make sure the sliders
-        act as "more cooling" when pushed up.
-        """
-        self.cool_factor = self.COOL_RANGE[0] + (1-(num/127.0))*self.cool_delta
-        logger.info("Set cooling to {0:.2f}".format(self.cool_factor))
 
     def heat_squares(self, weights, x, y):
         """Heat up squares based on proximity to step at x, y"""
@@ -100,13 +62,13 @@ class HeatStep(Base):
                 dist_y = abs(y - other_y)
                 if dist_x == 0 and dist_y == 0:
                     continue
-                scale = (DISTANCE[dist_y][dist_x]**2) * self.heat_factor
+                scale = (DISTANCE[dist_y][dist_x]**2) * self.HEAT
                 idx = (other_x * self.FLOOR_WIDTH) + other_y
                 pixel = self.pixels[idx]
 
                 # Set the hue and saturation of this heated square and increase or set the value
                 pixel[0] = self.secondary_hue
-                pixel[1] = self.saturation
+                pixel[1] = self.SAT
                 pixel[2] += self.value / scale
 
     def cool_floor(self):
@@ -117,16 +79,24 @@ class HeatStep(Base):
                 pixel = self.pixels[idx]
 
                 # Decrease the V of this HSV pixel
-                pixel[2] *= self.cool_factor
+                pixel[2] *= self.COOL
 
-    def get_next_frame(self, weights):
+    def set_secondary_hue(self):
+        self.secondary_hue = self.HUE + 0.5
+        if self.secondary_hue > 1.0:
+            self.secondary_hue -= 1.0
+
+    def get_next_frame(self, context):
+        weights = context.weights
+        self.set_secondary_hue()
+
         self.cool_floor()
 
         for y in range(8):
             for x in range(8):
                 idx = (x * self.FLOOR_WIDTH) + y
                 if weights[idx] > 0:
-                    self.pixels[idx] = [self.hue, self.saturation, self.value]
+                    self.pixels[idx] = [self.HUE, self.SAT, self.value]
                     self.heat_squares(weights, x, y)
 
         return self.hsv_to_rgb_pixels(self.pixels)

--- a/floor/floor/processor/hyperspace.py
+++ b/floor/floor/processor/hyperspace.py
@@ -23,7 +23,7 @@ class Hyperspace(Base):
         self.radius_map_1 = self.build_radius_map({'x':3.5, 'y':3.5});
         self.radius_map_2 = self.build_radius_map({'x':3, 'y':4});
 
-    #precompute distance of each pixel to the center
+    # precompute distance of each pixel to the center
     def build_radius_map(self, center):
         radius_map = [None] * 64
         for y in range(0, self.FLOOR_HEIGHT):

--- a/floor/floor/processor/ripple.py
+++ b/floor/floor/processor/ripple.py
@@ -1,15 +1,9 @@
 import colorsys
 import math
 from utils import clocked
-from utils import midictrl
-import logging
-
-from floor.controller.midi.functions import MidiFunctions
 
 from base import Base
 
-
-logger = logging.getLogger('ripple')
 
 # The distance from the center for every square
 DISTANCE = [
@@ -27,25 +21,24 @@ DISTANCE = [
 class Ripple(Base):
     """Spiral out from the center."""
 
-    # 0.75 is good for long pulses
-    DECAY_MAX = 2.0
-    DECAY_MIN = 0.25
-    DECAY_DELTA = DECAY_MAX - DECAY_MIN
-    DECAY_DEFAULT = 0.75
-    DECAY = DECAY_DEFAULT
+    CONTROLS = [
+        # Scale how far squares are from each other
+        {
+            'name': 'DISTANCE_FACTOR',
+            'range': [0.02, 0.18],
+            'default': 0.03
+        },
+        # How quickly do we dampen the waves
+        {
+            'name': 'DECAY',
+            'range': [0.25, 2.0],
+            'default': 0.75
+        },
+
+    ]
 
     OMEGA = 2 * math.pi
-    # How much distance translates the time value sent to the decay method.
-    # A number between 0.02 and 0.18 seems to look best.
-    #  - Lower than 0.02 and the whole floor seems to flash at once
-    #  - higher than 0.18 and there are too many striations and it looks noisy, not smooth
-    DISTANCE_FACTOR_MAX = 0.18
-    DISTANCE_FACTOR_MIN = 0.02
-    DISTANCE_FACTOR_DELTA = DISTANCE_FACTOR_MAX - DISTANCE_FACTOR_MIN
-    DISTANCE_FACTOR_DEFAULT = 0.03
-    DISTANCE_FACTOR = DISTANCE_FACTOR_DEFAULT
-
-    RESTART_THRESHHOLD = 0.01
+    RESTART_THRESHOLD = 0.01
 
     def __init__(self, **kwargs):
         super(Ripple, self).__init__(**kwargs)
@@ -55,18 +48,6 @@ class Ripple(Base):
 
     def requested_fps(self):
         return 120
-
-    @classmethod
-    @midictrl(function=MidiFunctions.ranged_value_1)
-    def update_distance_factor(cls, context_value, value):
-        cls.DISTANCE_FACTOR = (cls.DISTANCE_FACTOR_DELTA * (value / 127.0)) + cls.DISTANCE_FACTOR_MIN
-        logger.info("Set distance factor to {}".format(cls.DISTANCE_FACTOR))
-
-    @classmethod
-    @midictrl(function=MidiFunctions.ranged_value_2)
-    def update_distance_factor(cls, context_value, value):
-        cls.DECAY = (cls.DECAY_DELTA * (value / 127.0)) + cls.DECAY_MIN
-        logger.info("Set decay to {}".format(cls.DECAY))
 
     @clocked(frames_per_beat=0.125)
     def reset_on_beat(self, context):

--- a/floor/floor/processor/ripple_pulse.py
+++ b/floor/floor/processor/ripple_pulse.py
@@ -1,4 +1,3 @@
-import colorsys
 import math
 from utils import clocked
 

--- a/floor/floor/processor/simple_step.py
+++ b/floor/floor/processor/simple_step.py
@@ -1,16 +1,25 @@
-import logging
-import colorsys
-
 from base import Base
-from floor.controller import midi
-
-logger = logging.getLogger('simple_step')
 
 
 class SimpleStep(Base):
-    HUE_SLIDER = 48
-    SAT_SLIDER = 49
-    VAL_SLIDER = 50
+
+    CONTROLS = [
+        {
+            'name': 'HUE',
+            'scale': 1.0,
+            'default': 1.0
+        },
+        {
+            'name': 'SAT',
+            'scale': 1.0,
+            'default': 1.0
+        },
+        {
+            'name': 'VAL',
+            'scale': 1.0,
+            'default': 1.0
+        }
+    ]
 
     def __init__(self, **kwargs):
         super(SimpleStep, self).__init__(**kwargs)
@@ -21,26 +30,12 @@ class SimpleStep(Base):
         self.green = 0
         self.blue = 0
 
-    def handle_midi_command(self, command):
-        if command[0] == midi.COMMAND_CONTROL_MODE_CHANGE:
-            value = command[2]
-            if command[1] == self.HUE_SLIDER:
-                self.hue = value/127.0
-                logger.info("Set hue to {}/127".format(value))
-            if command[1] == self.SAT_SLIDER:
-                self.saturation = value/127.0
-                logger.info("Set saturation to {}/127".format(value))
-            if command[1] == self.VAL_SLIDER:
-                self.value = value/127.0
-                logger.info("Set value to {}/127".format(value))
-
-            self.red, self.green, self.blue = self.hsv_to_rgb([self.hue, self.saturation, self.value])
-
-    def get_next_frame(self, weights):
+    def get_next_frame(self, context):
+        weights = context.weights
         pixels = [(0, 0, 0)] * 64
 
         for idx in range(64):
             if weights[idx] > 0:
-                pixels[idx] = (self.red, self.green, self.blue)
+                pixels[idx] = self.hsv_to_rgb([self.HUE, self.SAT, self.VAL])
 
         return pixels

--- a/floor/floor/processor/utils.py
+++ b/floor/floor/processor/utils.py
@@ -1,5 +1,3 @@
-import inspect
-from floor.controller.midi.manager import MidiManager
 
 BLANK_FRAME = [(0, 0, 0)] * 64
 
@@ -53,39 +51,3 @@ class clocked(object):
             self.last_time = now
             return self.current_frame
         return new_fn
-
-
-class midictrl(object):
-    """Decorator that registers the class method as a midi function callback.
-
-    Only works on class methods as the decoration does not have access to the
-    instance (which has not been created) when its invoked.
-
-    Methods will be passed their class name, the context_value if provided (a constant
-    that is tied to a MidiFunction, e.g. ranged_value_6 will have a context value of 6),
-    and the value of the midi function itself. For note on/off this will be the note velocity,
-    for control functions, this will be the value of that control.  In both cases, the value
-    will be between 0 and 127.
-
-    Example usage:
-
-        @classmethod
-        @midictrl(function=MidiFunctions.ranged_value_1)
-        def adjust_speed(cls, context_value, value):
-            cls.SPEED = value/127.0
-    """
-    def __init__(self, function):
-        """Decorator constructor.
-
-        Args
-            function: A MidiFunctions function, e.g. MidiFunctions.ranged_value_1
-        """
-        self.function = function
-
-    def __call__(self, fn, *args, **kwargs):
-        stack = inspect.stack()
-        processor_class = stack[1][3]
-        midi_function = self.function
-
-        MidiManager.register_processor_callback(processor_class, midi_function, fn)
-        return fn

--- a/floor/floor/processor/utils.py
+++ b/floor/floor/processor/utils.py
@@ -1,4 +1,5 @@
-import time
+import inspect
+from floor.controller.midi.manager import MidiManager
 
 BLANK_FRAME = [(0, 0, 0)] * 64
 
@@ -52,3 +53,39 @@ class clocked(object):
             self.last_time = now
             return self.current_frame
         return new_fn
+
+
+class midictrl(object):
+    """Decorator that registers the class method as a midi function callback.
+
+    Only works on class methods as the decoration does not have access to the
+    instance (which has not been created) when its invoked.
+
+    Methods will be passed their class name, the context_value if provided (a constant
+    that is tied to a MidiFunction, e.g. ranged_value_6 will have a context value of 6),
+    and the value of the midi function itself. For note on/off this will be the note velocity,
+    for control functions, this will be the value of that control.  In both cases, the value
+    will be between 0 and 127.
+
+    Example usage:
+
+        @classmethod
+        @midictrl(function=MidiFunctions.ranged_value_1)
+        def adjust_speed(cls, context_value, value):
+            cls.SPEED = value/127.0
+    """
+    def __init__(self, function):
+        """Decorator constructor.
+
+        Args
+            function: A MidiFunctions function, e.g. MidiFunctions.ranged_value_1
+        """
+        self.function = function
+
+    def __call__(self, fn, *args, **kwargs):
+        stack = inspect.stack()
+        processor_class = stack[1][3]
+        midi_function = self.function
+
+        MidiManager.register_processor_callback(processor_class, midi_function, fn)
+        return fn


### PR DESCRIPTION
This re-implements the `MidiFunctions` usage as callbacks.  Using callbacks eliminates the big if/elif block and allows implementing an annotation for processors to use to link a midi function to some change in their settings.

I prefer having annotations for this rather than passing a block of recently seen midi info in context to `get_next_frame()`, because it allows `get_next_frame()` to focus on frame generation and not have a bunch of if/elif to update parameters.  It also allows the values to be set right when the message gets received, rather than saved somewhere until the next `get_next_frame()` call.

I also added a 'context_value' for MidiFunctions to pass things like `5` in `playlist_goto_5`.  This makes the callback possible when you want to use the same method to handle multiple `MidiFunctions` like this.