### PR TITLE
Simple profiler

### DIFF
--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -13,6 +13,7 @@ from floor.controller.rendering import PlaylistRenderLayer
 from floor.controller.rendering import ProcessorRenderLayer
 from floor.util.color_utils import blend_pixel_copy
 from floor.util.color_utils import normalize_pixel
+from floor.util.simple_profile import profile
 
 
 logger = logging.getLogger('controller')
@@ -125,6 +126,7 @@ class Controller(object):
         while True:
             self.run_one_frame()
 
+    @profile(print_seconds=2)
     def run_one_frame(self):
         if not self.playlist.is_running():
             # If the playlist is stopped/paused, sleep a bit then restart the loop
@@ -137,13 +139,16 @@ class Controller(object):
         self.transfer_data()
         self.delay()
 
+    @profile()
     def init_loop(self):
         self.frame_start = self.clocksource.time()
 
+    @profile()
     def prepare(self):
         for layer in self._iter_enabled_layers():
             layer.prepare()
 
+    @profile()
     def generate_frame(self):
         context = RenderContext(
             clock=self.frame_start,
@@ -170,6 +175,7 @@ class Controller(object):
         leds = map(lambda pixel: map(lambda color: color * self.brightness, pixel), composited_leds)
         self.driver.set_leds(leds)
 
+    @profile()
     def get_weights(self):
         weights = self.driver.get_weights()
         if self.SYNTHETIC_WEIGHT_ACTIVE:
@@ -180,10 +186,12 @@ class Controller(object):
 
         return weights
 
+    @profile()
     def transfer_data(self):
         self.driver.send_data()
         self.driver.read_data()
 
+    @profile()
     def delay(self):
         elapsed = self.clocksource.time() - self.frame_start
 

--- a/floor/floor/util/simple_profile.py
+++ b/floor/floor/util/simple_profile.py
@@ -1,0 +1,86 @@
+import time
+import os
+import logging
+
+
+class profile(object):
+    """Utility decorator that implements a simple profiler.
+    """
+
+    PROFILE_ENABLED = 'PROFILE' in os.environ and os.environ['PROFILE']
+    PROFILE_DATA = []
+
+    def __init__(self, print_seconds=None):
+        """Decorator constructor.
+
+        Args
+            print_seconds: If given, will print the timing results at the end of the
+            function call every print_seconds seconds and reset.  There should only be one of these.
+        """
+        self.print_seconds = print_seconds
+        if print_seconds:
+            print("Profiling enabled: output every {} seconds".format(print_seconds))
+
+    def __call__(self, fn, *args, **kwargs):
+        # Return the original function if profiling is not enabled
+        if not self.PROFILE_ENABLED:
+            return fn
+
+        function_name = fn.__name__
+
+        data = {
+            'name': function_name,
+            'calls': 0,
+            'cumulative': 0,
+            'print_seconds': self.print_seconds,
+            'last_print': time.time()
+        }
+
+        # Save our instance's profile data off in the global store
+        self.PROFILE_DATA.append(data)
+
+        def new_fn(*args, **kwargs):
+            data['calls'] += 1
+            start_time = time.time()
+
+            ret_val = fn(*args, **kwargs)
+
+            total = time.time() - start_time
+            data['cumulative'] += total
+
+            if data['print_seconds']:
+                if (time.time() - data['last_print']) > data['print_seconds']:
+                    print("---------------------------")
+                    print(" {: >5s} | {: >8s} | {: >8s} | {: >5s} | {}"
+                          .format('calls', 'percall', 'cumul', 'pct', 'func'))
+                    print_profile_line(data)
+                    for other_data in profile.PROFILE_DATA:
+                        # Don't print our data out again
+                        if other_data['name'] == data['name']:
+                            continue
+
+                        print_profile_line(other_data, data['print_seconds'])
+                        other_data['calls'] = 0
+                        other_data['cumulative'] = 0
+
+                    data['calls'] = 0
+                    data['cumulative'] = 0
+                    data['last_print'] = time.time()
+
+            return ret_val
+
+        return new_fn
+
+
+def print_profile_line(data, total=None):
+    name = data['name']
+    calls = data['calls']
+    cumulative = data['cumulative']
+    per_call = float(data['cumulative']) / data['calls']
+
+    if total:
+        pct = '{: >5.2f}'.format(100 * (cumulative / float(total)))
+    else:
+        pct = '{: >5s}'.format('--')
+
+    print(" {: >5d} | {: >8.3f} | {: >8.3f} | {} | {}".format(calls, per_call*1000, cumulative*1000, pct, name))

--- a/floor/floor/util/simple_profile.py
+++ b/floor/floor/util/simple_profile.py
@@ -7,19 +7,66 @@ class profile(object):
     """Utility decorator that implements a simple profiler.
     """
 
+    __INSTANCE = None
     PROFILE_ENABLED = 'PROFILE' in os.environ and os.environ['PROFILE']
-    PROFILE_DATA = []
 
-    def __init__(self, print_seconds=None):
-        """Decorator constructor.
+    def __new__(cls, print_seconds=None):
+        if profile.__INSTANCE is None:
+            profile.__INSTANCE = object.__new__(cls)
+            profile.__INSTANCE.data = []
 
-        Args
-            print_seconds: If given, will print the timing results at the end of the
-            function call every print_seconds seconds and reset.  There should only be one of these.
-        """
-        self.print_seconds = print_seconds
         if print_seconds:
+            profile.__INSTANCE.print_seconds = print_seconds
             print("Profiling enabled: output every {} seconds".format(print_seconds))
+
+        return profile.__INSTANCE
+
+    @classmethod
+    def instance(cls):
+        return cls.__INSTANCE
+
+    def init_timer(self, name):
+        timer = {
+            'name': name,
+            'calls': 0,
+            'cumulative': 0,
+            'print_seconds': self.print_seconds,
+            'last_print': time.time()
+        }
+        self.data.append(timer)
+        return timer
+
+    def print_profiling_data(self):
+        self.data.sort(key=lambda v: v['cumulative'], reverse=True)
+
+        # Total time spent will be the wrapper, which should have the highest time
+        total_time = self.data[0]['cumulative']
+
+        print("---------------------------")
+        print(" {: >5s} | {: >8s} | {: >8s} | {: >6s} | {}"
+              .format('calls', 'percall', 'cumul', 'pct', 'func'))
+        for timer in self.data:
+            self.print_profile_line(timer, total_time)
+            self.reset_timer(timer)
+
+    @classmethod
+    def print_profile_line(cls, data, total):
+        name = data['name']
+        calls = data['calls']
+        cumulative = data['cumulative']
+        per_call = float(data['cumulative']) / data['calls']
+        pct = 100 * (cumulative / float(total))
+
+        # Print times in microseconds
+        print(" {: >5d} | {: >8.3f} | {: >8.3f} | {: >6.2f} | {}"
+              .format(calls, per_call*1000, cumulative*1000, pct, name))
+
+    @classmethod
+    def reset_timer(cls, timer):
+        timer['calls'] = 0
+        timer['cumulative'] = 0
+        if timer['last_print']:
+            timer['last_print'] = time.time()
 
     def __call__(self, fn, *args, **kwargs):
         # Return the original function if profiling is not enabled
@@ -27,60 +74,21 @@ class profile(object):
             return fn
 
         function_name = fn.__name__
-
-        data = {
-            'name': function_name,
-            'calls': 0,
-            'cumulative': 0,
-            'print_seconds': self.print_seconds,
-            'last_print': time.time()
-        }
-
-        # Save our instance's profile data off in the global store
-        self.PROFILE_DATA.append(data)
+        timer = self.init_timer(function_name)
 
         def new_fn(*args, **kwargs):
-            data['calls'] += 1
+            timer['calls'] += 1
             start_time = time.time()
 
             ret_val = fn(*args, **kwargs)
 
             total = time.time() - start_time
-            data['cumulative'] += total
+            timer['cumulative'] += total
 
-            if data['print_seconds']:
-                if (time.time() - data['last_print']) > data['print_seconds']:
-                    print("---------------------------")
-                    print(" {: >5s} | {: >8s} | {: >8s} | {: >5s} | {}"
-                          .format('calls', 'percall', 'cumul', 'pct', 'func'))
-                    print_profile_line(data)
-                    for other_data in profile.PROFILE_DATA:
-                        # Don't print our data out again
-                        if other_data['name'] == data['name']:
-                            continue
-
-                        print_profile_line(other_data, data['print_seconds'])
-                        other_data['calls'] = 0
-                        other_data['cumulative'] = 0
-
-                    data['calls'] = 0
-                    data['cumulative'] = 0
-                    data['last_print'] = time.time()
+            if timer['print_seconds']:
+                if (time.time() - timer['last_print']) > timer['print_seconds']:
+                    profile.instance().print_profiling_data()
 
             return ret_val
 
         return new_fn
-
-
-def print_profile_line(data, total=None):
-    name = data['name']
-    calls = data['calls']
-    cumulative = data['cumulative']
-    per_call = float(data['cumulative']) / data['calls']
-
-    if total:
-        pct = '{: >5.2f}'.format(100 * (cumulative / float(total)))
-    else:
-        pct = '{: >5s}'.format('--')
-
-    print(" {: >5d} | {: >8.3f} | {: >8.3f} | {} | {}".format(calls, per_call*1000, cumulative*1000, pct, name))

--- a/floor/run-show.py
+++ b/floor/run-show.py
@@ -7,6 +7,7 @@ from floor.controller import Layout
 from floor.controller.midi import MidiManager
 from floor.server.server import run_server
 from floor.processor import all_processors
+from floor.util.simple_profile import profile
 
 import argparse
 import importlib
@@ -25,11 +26,12 @@ DEFAULT_FLOOR_CONFIG_FILE = os.path.join(SCRIPT_DIR, 'config/floor-layout.json')
 
 logger = logging.getLogger('show')
 
+
 def load_driver(driver_name, driver_args):
     try:
         module = importlib.import_module("floor.driver.{}".format(driver_name))
     except ImportError as e:
-        logger.exception("Driver '{}' does not exist or could not be loaded".format(driver_name))
+        logger.exception("Driver '{}' does not exist or could not be loaded: {}".format(driver_name, e))
         return None
 
     driver = getattr(module, driver_name.title())(driver_args)
@@ -103,6 +105,7 @@ def get_options():
     parser.set_defaults(opc_input=True, server_port=1977)
     return parser.parse_args()
 
+
 def main():
     args = get_options()
     log_level = logging.DEBUG if args.verbose else logging.INFO
@@ -153,8 +156,9 @@ def main():
         logger.info('Got CTRL-C, quitting.')
         sys.exit(0)
     except Exception as e:
-        logger.exception('Unexpected error, aborting.')
+        logger.exception('Unexpected error, aborting: {}'.format(e))
         sys.exit(1)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Add a basic annotation based profiler.  In theory it could be applied to any set of methods, but in practice its really just meant for the frame generation functions.

NOTE: This is based on the layer PR that (as of now) has not been submitted.  This PR will become much more readable when that is merged.

The `@profile()` annotation marks a function to be profiled.  If its given the `print_seconds` arg, then its assumed that this is a function call that wraps the others, and when it has executed that number of seconds, that particular profile instance will spit out the current numbers and reset.

Profiling is enabled by setting the PROFILE env variable, e.g.

```bash
PROFILE=1 python run-show.py --driver devserver --processor Spiral
```

Sample output looks like:
```bash
---------------------------
 calls |  percall |    cumul |    pct | func
   214 |    9.375 | 2006.146 | 100.00 | run_one_frame
   214 |    8.753 | 1873.122 |  93.37 | delay
   214 |    0.399 |   85.326 |   4.25 | generate_frame
   214 |    0.156 |   33.357 |   1.66 | transfer_data
   214 |    0.031 |    6.698 |   0.33 | prepare
   214 |    0.031 |    6.600 |   0.33 | get_weights
   214 |    0.003 |    0.725 |   0.04 | init_loop
```