### PR TITLE
cleanup: replace `Processor.max_value` with `COLOR_MAXIMUM`

### DIFF
--- a/floor/floor/processor/README.md
+++ b/floor/floor/processor/README.md
@@ -18,7 +18,7 @@ class YourPattern(Base):
 
         # Do something with list of context.weight values
 
-        # Compute a list of RGB tuples, limit by self.max_value
+        # Compute a list of RGB tuples, limit by COLOR_MAXIMUM
         # which gets set for you based on driver at object creation
 
         return pixels

--- a/floor/floor/processor/balls.py
+++ b/floor/floor/processor/balls.py
@@ -3,6 +3,7 @@ import math
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Balls(Base):
@@ -19,9 +20,9 @@ class Balls(Base):
         self.in_flight = []
 
     def rand_color(self):
-        return [random.randrange(self.max_value),
-                random.randrange(self.max_value),
-                random.randrange(self.max_value)]
+        return [random.randrange(COLOR_MAXIMUM),
+                random.randrange(COLOR_MAXIMUM),
+                random.randrange(COLOR_MAXIMUM)]
 
     def can_spawn_ball(self):
         """Max self.spawn_chance chance of spawning a ball, modulated by a sine curve.

--- a/floor/floor/processor/base.py
+++ b/floor/floor/processor/base.py
@@ -54,7 +54,6 @@ class Base(object):
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.weights = []
-        self.max_value = COLOR_MAXIMUM
         self.ranged_values = []
 
         self._controls = []
@@ -143,9 +142,9 @@ class Base(object):
         """Convert a pixel tuple of [h, s, v] to a tuple of [r, g, b]
 
         HSV values are assumed to range from 0.0 to 1.0
-        RGB values are adjusted to range from 0 to self.max_value
+        RGB values are adjusted to range from 0 to COLOR_MAXIMUM
         """
-        return [int(v * self.max_value) for v in colorsys.hsv_to_rgb(p[0], p[1], p[2])]
+        return [int(v * COLOR_MAXIMUM) for v in colorsys.hsv_to_rgb(p[0], p[1], p[2])]
 
     def hsv_to_rgb_pixels(self, pixels):
         """Convert an array of HSV pixels to an array of RGB pixels"""

--- a/floor/floor/processor/chachacha.py
+++ b/floor/floor/processor/chachacha.py
@@ -3,6 +3,7 @@ import itertools
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 BLACK = (0, 0, 0)
 RED = (1, 0, 0)
@@ -33,6 +34,6 @@ class ChaChaCha(Base):
     def get_next_frame(self, context):
         lines = list(itertools.islice(self.lines, 0, 8))
         self.lines.rotate()
-        pixels = [(pixel[0] * self.max_value, pixel[1] * self.max_value, pixel[2] * self.max_value)
+        pixels = [(pixel[0] * COLOR_MAXIMUM, pixel[1] * COLOR_MAXIMUM, pixel[2] * COLOR_MAXIMUM)
                   for line in lines for pixel in line]
         return pixels

--- a/floor/floor/processor/color_wash.py
+++ b/floor/floor/processor/color_wash.py
@@ -1,5 +1,6 @@
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class ColorWash(Base):
@@ -16,9 +17,9 @@ class ColorWash(Base):
         for x in range(0, 8):
             for y in range(0, 8):
                 pixels.append((
-                    (self.red * x) % self.max_value,
-                    (self.green * y) % self.max_value,
-                    self.blue % self.max_value
+                    (self.red * x) % COLOR_MAXIMUM,
+                    (self.green * y) % COLOR_MAXIMUM,
+                    self.blue % COLOR_MAXIMUM
                 ))
 
         self.red += 1

--- a/floor/floor/processor/electricity.py
+++ b/floor/floor/processor/electricity.py
@@ -4,6 +4,7 @@ import logging
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 logger = logging.getLogger('electricity')
@@ -58,7 +59,7 @@ class Electricity(Base):
 
         for idx, val in enumerate(arc.frame):
             if len(val) > 0:
-                self.pixels[idx] = val  # [val * self.max_value, val * self.max_value, val * self.max_value]
+                self.pixels[idx] = val  # [val * COLOR_MAXIMUM, val * COLOR_MAXIMUM, val * COLOR_MAXIMUM]
 
     def fade_frame(self):
         for idx in range(64):

--- a/floor/floor/processor/fire.py
+++ b/floor/floor/processor/fire.py
@@ -4,6 +4,7 @@ import math
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Fire(Base):
@@ -40,9 +41,9 @@ class Fire(Base):
             if row_pos <= 7:
                 index = int(round(ember.position)) + (ember.row*8)
                 r, g, b = colorsys.hsv_to_rgb(ember.hue, 1.0, 1.0)
-                pixels[index] = [int(r*self.max_value),
-                                 int(g*self.max_value),
-                                 int(b*self.max_value)]
+                pixels[index] = [int(r * COLOR_MAXIMUM),
+                                 int(g * COLOR_MAXIMUM),
+                                 int(b * COLOR_MAXIMUM)]
 
             ember.run()
 

--- a/floor/floor/processor/fishies.py
+++ b/floor/floor/processor/fishies.py
@@ -4,14 +4,15 @@ import time
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Fishies(Base):
     def __init__(self, **kwargs):
         super(Fishies, self).__init__(**kwargs)
         self.pixels = []
-        # self.palette = color.get_random_palette(self.max_value)
-        self.palette = color.get_palette('rainbow_bunny', self.max_value)
+        # self.palette = color.get_random_palette(COLOR_MAXIMUM)
+        self.palette = color.get_palette('rainbow_bunny', COLOR_MAXIMUM)
         self.palette_length = len(self.palette)
         self.fishies = self.init_fishies()
         self.last_time = None

--- a/floor/floor/processor/flash_bang.py
+++ b/floor/floor/processor/flash_bang.py
@@ -3,6 +3,7 @@ import math
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class FlashBang(Base):
@@ -32,11 +33,11 @@ class FlashBang(Base):
         self.burst_decay = self.BURST_DECAY_MAX
         self.burst_intensity = self.BURST_INTENSITY_MAX
 
-        self.burst_red = self.max_value
-        self.burst_green = self.max_value
-        self.burst_blue = self.max_value
+        self.burst_red = COLOR_MAXIMUM
+        self.burst_green = COLOR_MAXIMUM
+        self.burst_blue = COLOR_MAXIMUM
 
-        self.sparkle_trigger = self.SPARKLE_TRIGGER_MAX * self.max_value
+        self.sparkle_trigger = self.SPARKLE_TRIGGER_MAX * COLOR_MAXIMUM
         self.sparkle_start = False
         self.sparkling = False
 
@@ -90,9 +91,9 @@ class FlashBang(Base):
 
         burst_x = random.randint(0, 7)
         burst_y = random.randint(0, 7)
-        self.burst_red = random.randint(int(self.max_value * 0.8), self.max_value*2)
-        self.burst_green = random.randint(int(self.max_value * 0.8), self.max_value*2)
-        self.burst_blue = random.randint(int(self.max_value * 0.8), self.max_value*2)
+        self.burst_red = random.randint(int(COLOR_MAXIMUM * 0.8), COLOR_MAXIMUM*2)
+        self.burst_green = random.randint(int(COLOR_MAXIMUM * 0.8), COLOR_MAXIMUM*2)
+        self.burst_blue = random.randint(int(COLOR_MAXIMUM * 0.8), COLOR_MAXIMUM*2)
 
         for x in range(0, 8):
             for y in range(0, 8):

--- a/floor/floor/processor/hyperspace.py
+++ b/floor/floor/processor/hyperspace.py
@@ -4,6 +4,7 @@ import math
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Hyperspace(Base):
@@ -14,8 +15,8 @@ class Hyperspace(Base):
         super(Hyperspace, self).__init__(**kwargs)
         self.pixels = []
         self.times = [0 for _ in range(64)]
-        # self.palette = color.get_random_palette(self.max_value)
-        self.palette = color.get_palette('rainbow_bunny', self.max_value)
+        # self.palette = color.get_random_palette(COLOR_MAXIMUM)
+        self.palette = color.get_palette('rainbow_bunny', COLOR_MAXIMUM)
         self.palette_length = len(self.palette)
         self.radius_map_1 = [None] * 64
         self.radius_map_2 = [None] * 64

--- a/floor/floor/processor/kaleidoscope.py
+++ b/floor/floor/processor/kaleidoscope.py
@@ -3,6 +3,7 @@ import random
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Kaleidoscope(Base):
@@ -13,7 +14,7 @@ class Kaleidoscope(Base):
         super(Kaleidoscope, self).__init__(**kwargs)
         self.active_px = []
         self.times = [0 for _ in range(64)]
-        self.palette = color.get_random_palette(self.max_value)
+        self.palette = color.get_random_palette(COLOR_MAXIMUM)
         self.palette_length = len(self.palette)
 
         for x in range(0, 64):

--- a/floor/floor/processor/land_mines.py
+++ b/floor/floor/processor/land_mines.py
@@ -4,6 +4,7 @@ import math
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color_utils
+from floor.processor.constants import COLOR_MAXIMUM
 
 life_time = 4
 
@@ -14,7 +15,7 @@ class LandMines(Base):
         self.pixels = []
         self.mines = []
         self.walkers = self.init_walkers()
-        self.palette = color_utils.get_random_palette(self.max_value)
+        self.palette = color_utils.get_random_palette(COLOR_MAXIMUM)
         self.palette_length = len(self.palette)
         for x in range(0, 8):
             for y in range(0, 8):
@@ -67,7 +68,7 @@ class LandMines(Base):
             self.pixels[mine['y']*8 + mine['x']] = mine['color']
 
         time_delta = 0.1
-        velocity = 0.0003 * self.max_value
+        velocity = 0.0003 * COLOR_MAXIMUM
         live_mines = []
         for index in xrange(len(self.mines)):
             mine = self.mines[index]

--- a/floor/floor/processor/life.py
+++ b/floor/floor/processor/life.py
@@ -2,6 +2,7 @@ import datetime
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Life(Base):
@@ -92,7 +93,7 @@ class Life(Base):
 
         # render active_px
         dark = (0, 0, 0)
-        bright = (self.max_value, self.max_value, self.max_value)
+        bright = (COLOR_MAXIMUM, COLOR_MAXIMUM, COLOR_MAXIMUM)
         pixels = []
         for y in range(0, self.FLOOR_HEIGHT):
             for x in range(0, self.FLOOR_WIDTH):

--- a/floor/floor/processor/line_slam.py
+++ b/floor/floor/processor/line_slam.py
@@ -4,6 +4,7 @@ import math
 from floor.util.easing import Easing
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class LineSlam(Base):
@@ -51,9 +52,9 @@ class LineSlam(Base):
         for y in range(8):
             for x in range(8):
                 if y == int(cur):
-                    pixels.append((int(self.max_value * pre), 0, 0))
+                    pixels.append((int(COLOR_MAXIMUM * pre), 0, 0))
                 elif y == int(cur+1):
-                    pixels.append((int(self.max_value * post), 0, 0))
+                    pixels.append((int(COLOR_MAXIMUM * post), 0, 0))
                 else:
                     pixels.append((0, 0, 0))
 
@@ -72,7 +73,7 @@ class LineSlam(Base):
             for x in range(8):
                 if y == 7:
                     r, g, b = colorsys.hsv_to_rgb(0.0, cur, 1.0 - cur)
-                    pixels.append((self.max_value * r, self.max_value * g, self.max_value * b))
+                    pixels.append((COLOR_MAXIMUM * r, COLOR_MAXIMUM * g, COLOR_MAXIMUM * b))
                 else:
                     pixels.append((0, 0, 0))
 

--- a/floor/floor/processor/message.py
+++ b/floor/floor/processor/message.py
@@ -4,6 +4,7 @@ import importlib
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Message(Base):
@@ -118,9 +119,9 @@ class Message(Base):
         rgb_float = colorsys.hsv_to_rgb(self.hue, self.saturation, self.value)
         rgb = list()
 
-        rgb.append(int(rgb_float[0] * self.max_value))
-        rgb.append(int(rgb_float[1] * self.max_value))
-        rgb.append(int(rgb_float[2] * self.max_value))
+        rgb.append(int(rgb_float[0] * COLOR_MAXIMUM))
+        rgb.append(int(rgb_float[1] * COLOR_MAXIMUM))
+        rgb.append(int(rgb_float[2] * COLOR_MAXIMUM))
 
         return rgb
 

--- a/floor/floor/processor/pulsar.py
+++ b/floor/floor/processor/pulsar.py
@@ -2,6 +2,7 @@ import random
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Pulsar(Base):
@@ -57,9 +58,9 @@ class Pulsar(Base):
         for i in range(0, 64):
             if weights[i] > 0:
                 self.pixels[i] = (
-                    self.max_value * random.random(),
-                    self.max_value * random.random(),
-                    self.max_value * random.random())
+                    COLOR_MAXIMUM * random.random(),
+                    COLOR_MAXIMUM * random.random(),
+                    COLOR_MAXIMUM * random.random())
 
     def random_weight_input(self):
         count = random.randint(1, 5)
@@ -67,9 +68,9 @@ class Pulsar(Base):
             # index: pick a random square for the source
             index = random.randint(0, 63)
             self.pixels[index] = (
-                self.max_value*random.random(),
-                self.max_value*random.random(),
-                self.max_value*random.random()
+                COLOR_MAXIMUM * random.random(),
+                COLOR_MAXIMUM * random.random(),
+                COLOR_MAXIMUM * random.random()
             )
 
     @clocked(frames_per_second=24)
@@ -106,7 +107,7 @@ class Pulsar(Base):
         # propagate the blossoms
         self_decay = 0.9
         wave_decay = 0.5
-        adjusted_max = 0.8 * self.max_value
+        adjusted_max = 0.8 * COLOR_MAXIMUM
 
         next_pixels = []
         for y in range(0, 8):

--- a/floor/floor/processor/random_decay.py
+++ b/floor/floor/processor/random_decay.py
@@ -2,6 +2,7 @@ import random
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class RandomDecay(Base):
@@ -15,9 +16,9 @@ class RandomDecay(Base):
         for x in range(0, 8):
             for y in range(0, 8):
                 self.pixels.append((
-                    self.max_value*random.random(),
-                    self.max_value*random.random(),
-                    self.max_value*random.random()
+                    COLOR_MAXIMUM * random.random(),
+                    COLOR_MAXIMUM * random.random(),
+                    COLOR_MAXIMUM * random.random()
                 ))
 
     @clocked(frames_per_second=24)
@@ -32,9 +33,9 @@ class RandomDecay(Base):
                 next_blue = decay_rate*next_pixel[1]
                 next_green = decay_rate*next_pixel[2]
                 if (next_red + next_blue + next_green) < 10:
-                    next_red = self.max_value*random.random()
-                    next_blue = self.max_value*random.random()
-                    next_green = self.max_value*random.random()
+                    next_red = COLOR_MAXIMUM * random.random()
+                    next_blue = COLOR_MAXIMUM * random.random()
+                    next_green = COLOR_MAXIMUM * random.random()
                 next_pixels.append((
                     next_red,
                     next_blue,

--- a/floor/floor/processor/raver_plaid.py
+++ b/floor/floor/processor/raver_plaid.py
@@ -3,6 +3,7 @@ import math
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.util import color_utils
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class RaverPlaid(Base):
@@ -43,13 +44,13 @@ class RaverPlaid(Base):
 
             # 3 sine waves for r, g, b which are out of sync with each other
             r = blackstripes * color_utils.remap(
-                math.cos((t / self.speed_r + pct * self.freq_r) * math.pi * 2), -1, 1, 0, self.max_value)
+                math.cos((t / self.speed_r + pct * self.freq_r) * math.pi * 2), -1, 1, 0, COLOR_MAXIMUM)
 
             g = blackstripes * color_utils.remap(
-                math.cos((t / self.speed_g + pct * self.freq_g) * math.pi * 2), -1, 1, 0, self.max_value)
+                math.cos((t / self.speed_g + pct * self.freq_g) * math.pi * 2), -1, 1, 0, COLOR_MAXIMUM)
 
             b = blackstripes * color_utils.remap(
-                math.cos((t / self.speed_b + pct * self.freq_b) * math.pi * 2), -1, 1, 0, self.max_value)
+                math.cos((t / self.speed_b + pct * self.freq_b) * math.pi * 2), -1, 1, 0, COLOR_MAXIMUM)
 
             pixels.append((r, g, b))
 

--- a/floor/floor/processor/ripple.py
+++ b/floor/floor/processor/ripple.py
@@ -3,6 +3,7 @@ import math
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 # The distance from the center for every square
@@ -74,7 +75,7 @@ class Ripple(Base):
             else:
                 r, g, b = colorsys.hsv_to_rgb(self.hue, 0.5, -1 * factor)
 
-            pixels.append([r * self.max_value, g * self.max_value, b * self.max_value])
+            pixels.append([r * COLOR_MAXIMUM, g * COLOR_MAXIMUM, b * COLOR_MAXIMUM])
 
         return pixels
 

--- a/floor/floor/processor/simple_step.py
+++ b/floor/floor/processor/simple_step.py
@@ -1,5 +1,6 @@
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class SimpleStep(Base):
@@ -27,7 +28,7 @@ class SimpleStep(Base):
         self.hue = 1.0
         self.saturation = 1.0
         self.value = 1.0
-        self.red = self.max_value
+        self.red = COLOR_MAXIMUM
         self.green = 0
         self.blue = 0
 
@@ -38,6 +39,6 @@ class SimpleStep(Base):
 
         for idx in range(64):
             if weights[idx] > 0:
-                pixels[idx] = self.hsv_to_rgb([self.HUE, self.SAT, self.VAL])
+                pixels[idx] = self.hsv_to_rgb([self.hue, self.saturation, self.value])
 
         return pixels

--- a/floor/floor/processor/spiral.py
+++ b/floor/floor/processor/spiral.py
@@ -3,6 +3,7 @@ import colorsys
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
 
 #  0  1  2  3  4  5  6  7
 #  8  9 10 11 12 13 14 15
@@ -88,7 +89,7 @@ class Spiral(Base):
         self.count = (self.count + 1) % self.count_mod
 
         r, g, b = colorsys.hsv_to_rgb(jump_hue, self.sat, self.val)
-        pixel = [r * self.max_value, g * self.max_value, b * self.max_value]
+        pixel = [r * COLOR_MAXIMUM, g * COLOR_MAXIMUM, b * COLOR_MAXIMUM]
 
         self.train.pop()
         self.train.appendleft(pixel)

--- a/floor/floor/processor/stripes.py
+++ b/floor/floor/processor/stripes.py
@@ -3,6 +3,7 @@ import random
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.util import color_utils
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Stripes(Base):
@@ -13,7 +14,7 @@ class Stripes(Base):
 
     def __init__(self, **kwargs):
         super(Stripes, self).__init__(**kwargs)
-        self.palette = color_utils.get_random_palette(self.max_value)
+        self.palette = color_utils.get_random_palette(COLOR_MAXIMUM)
         self.gradient = [[] for _ in range(len(self.palette))]
         self.stripes = [None for _ in range(8)]  # list[Stripe]
 

--- a/floor/floor/processor/test.py
+++ b/floor/floor/processor/test.py
@@ -1,5 +1,7 @@
 from floor.processor.base import Base
 from floor.processor.utils import clocked
+from floor.processor.constants import COLOR_MAXIMUM
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Test(Base):
@@ -12,9 +14,9 @@ class Test(Base):
 
         # helpful colors
         dark = (0, 0, 0)
-        red = (self.max_value, 0, 0)
-        blue = (0, self.max_value, 0)
-        green = (0, 0, self.max_value)
+        red = (COLOR_MAXIMUM, 0, 0)
+        blue = (0, COLOR_MAXIMUM, 0)
+        green = (0, 0, COLOR_MAXIMUM)
 
         # define cycles
         self.cycles = []

--- a/floor/floor/processor/test_step.py
+++ b/floor/floor/processor/test_step.py
@@ -1,6 +1,7 @@
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.util import color_utils
+from floor.processor.constants import COLOR_MAXIMUM
 
 
 def create(args=None):
@@ -26,7 +27,7 @@ class TestStep(Base):
                 w = 0
 
             val = color_utils.clamp(w, 0, 40)
-            val = color_utils.remap(1.0 * val, 0, self.MAX_WEIGHT, 0, self.max_value)
+            val = color_utils.remap(1.0 * val, 0, self.MAX_WEIGHT, 0, COLOR_MAXIMUM)
             pixels.append((val, val, 0))
 
         return pixels


### PR DESCRIPTION
As of #44 the color scale is global and does not vary (outside
of driver implementations), so there is no instance-level use for 
`self.max_value`. Purely mechanical cleanup.