### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - '2.7'
+  - '3.6'
 
 install:
   - cd floor

--- a/floor/Pipfile
+++ b/floor/Pipfile
@@ -22,5 +22,3 @@ gevent = "*"
 show = "python run-show.py"
 benchmark = "python bin/benchmark.py"
 
-[requires]
-python_version = "2.7"

--- a/floor/Pipfile
+++ b/floor/Pipfile
@@ -8,6 +8,7 @@ nose = "*"
 mock = "*"
 freezegun = "*"
 e1839a8 = {path = ".",editable = true}
+future = "*"
 
 [packages]
 pyserial = "*"

--- a/floor/Pipfile.lock
+++ b/floor/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1bc48018dedb1407f9bd9e631d57d35b3c24f1766724f0fa9b18a9edae6fc599"
+            "sha256": "792874bb31dbf6b3e33eef597f78082dd9acfddadc82d0ab0be4453c2000cb48"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,32 +61,32 @@
         },
         "gevent": {
             "hashes": [
-                "sha256:1f277c5cf060b30313c5f9b91588f4c645e11839e14a63c83fcf6f24b1bc9b95",
-                "sha256:298a04a334fb5e3dcd6f89d063866a09155da56041bc94756da59db412cb45b1",
-                "sha256:30e9b2878d5b57c68a40b3a08d496bcdaefc79893948989bb9b9fab087b3f3c0",
-                "sha256:33533bc5c6522883e4437e901059fe5afa3ea74287eeea27a130494ff130e731",
-                "sha256:3f06f4802824c577272960df003a304ce95b3e82eea01dad2637cc8609c80e2c",
-                "sha256:419fd562e4b94b91b58cccb3bd3f17e1a11f6162fca6c591a7822bc8a68f023d",
-                "sha256:4ea938f44b882e02cca9583069d38eb5f257cc15a03e918980c307e7739b1038",
-                "sha256:51143a479965e3e634252a0f4a1ea07e5307cf8dc773ef6bf9dfe6741785fb4c",
-                "sha256:5bf9bd1dd4951552d9207af3168f420575e3049016b9c10fe0c96760ce3555b7",
-                "sha256:6004512833707a1877cc1a5aea90fd182f569e089bc9ab22a81d480dad018f1b",
-                "sha256:640b3b52121ab519e0980cb38b572df0d2bc76941103a697e828c13d76ac8836",
-                "sha256:6951655cc18b8371d823e81c700883debb0f633aae76f425dfeb240f76b95a67",
-                "sha256:71eeb8d9146e8131b65c3364bb760b097c21b7b9fdbec91bf120685a510f997a",
-                "sha256:7c899e5a6f94d6310352716740f05e41eb8c52d995f27fc01e90380913aa8f22",
-                "sha256:8465f84ba31aaf52a080837e9c5ddd592ab0a21dfda3212239ce1e1796f4d503",
-                "sha256:99de2e38dde8669dd30a8a1261bdb39caee6bd00a5f928d01dfdb85ab0502562",
-                "sha256:9fa4284b44bc42bef6e437488d000ae37499ccee0d239013465638504c4565b7",
-                "sha256:a1beea0443d3404c03e069d4c4d9fc13d8ec001771c77f9a23f01911a41f0e49",
-                "sha256:a66a26b78d90d7c4e9bf9efb2b2bd0af49234604ac52eaca03ea79ac411e3f6d",
-                "sha256:a94e197bd9667834f7bb6bd8dff1736fab68619d0f8cd78a9c1cebe3c4944677",
-                "sha256:ac0331d3a3289a3d16627742be9c8969f293740a31efdedcd9087dadd6b2da57",
-                "sha256:d26b57c50bf52fb38dadf3df5bbecd2236f49d7ac98f3cf32d6b8a2d25afc27f",
-                "sha256:fd23b27387d76410eb6a01ea13efc7d8b4b95974ba212c336e8b1d6ab45a9578"
+                "sha256:0774babec518a24d9a7231d4e689931f31b332c4517a771e532002614e270a64",
+                "sha256:0e1e5b73a445fe82d40907322e1e0eec6a6745ca3cea19291c6f9f50117bb7ea",
+                "sha256:0ff2b70e8e338cf13bedf146b8c29d475e2a544b5d1fe14045aee827c073842c",
+                "sha256:107f4232db2172f7e8429ed7779c10f2ed16616d75ffbe77e0e0c3fcdeb51a51",
+                "sha256:14b4d06d19d39a440e72253f77067d27209c67e7611e352f79fe69e0f618f76e",
+                "sha256:1b7d3a285978b27b469c0ff5fb5a72bcd69f4306dbbf22d7997d83209a8ba917",
+                "sha256:1eb7fa3b9bd9174dfe9c3b59b7a09b768ecd496debfc4976a9530a3e15c990d1",
+                "sha256:2711e69788ddb34c059a30186e05c55a6b611cb9e34ac343e69cf3264d42fe1c",
+                "sha256:28a0c5417b464562ab9842dd1fb0cc1524e60494641d973206ec24d6ec5f6909",
+                "sha256:3249011d13d0c63bea72d91cec23a9cf18c25f91d1f115121e5c9113d753fa12",
+                "sha256:44089ed06a962a3a70e96353c981d628b2d4a2f2a75ea5d90f916a62d22af2e8",
+                "sha256:4bfa291e3c931ff3c99a349d8857605dca029de61d74c6bb82bd46373959c942",
+                "sha256:50024a1ee2cf04645535c5ebaeaa0a60c5ef32e262da981f4be0546b26791950",
+                "sha256:53b72385857e04e7faca13c613c07cab411480822ac658d97fd8a4ddbaf715c8",
+                "sha256:74b7528f901f39c39cdbb50cdf08f1a2351725d9aebaef212a29abfbb06895ee",
+                "sha256:7d0809e2991c9784eceeadef01c27ee6a33ca09ebba6154317a257353e3af922",
+                "sha256:896b2b80931d6b13b5d9feba3d4eebc67d5e6ec54f0cf3339d08487d55d93b0e",
+                "sha256:8d9ec51cc06580f8c21b41fd3f2b3465197ba5b23c00eb7d422b7ae0380510b0",
+                "sha256:9f7a1e96fec45f70ad364e46de32ccacab4d80de238bd3c2edd036867ccd48ad",
+                "sha256:ab4dc33ef0e26dc627559786a4fba0c2227f125db85d970abbf85b77506b3f51",
+                "sha256:d1e6d1f156e999edab069d79d890859806b555ce4e4da5b6418616322f0a3df1",
+                "sha256:d752bcf1b98174780e2317ada12013d612f05116456133a6acf3e17d43b71f05",
+                "sha256:e5bcc4270671936349249d26140c267397b7b4b1381f5ec8b13c53c5b53ab6e1"
             ],
             "index": "pypi",
-            "version": "==1.3.7"
+            "version": "==1.4.0"
         },
         "gevent-websocket": {
             "hashes": [
@@ -136,36 +136,36 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "mock": {
             "hashes": [
@@ -177,10 +177,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
-                "sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387"
+                "sha256:8257baf496c8522437e8a6cfe0f15e00aedc6c0e0e7c9d55eeeeab31e0853843",
+                "sha256:8c361cc353d988e4f5b998555c88098b9d5964c2e11acf7b0d21925a66bb5824"
             ],
-            "version": "==5.1.1"
+            "version": "==5.1.3"
         },
         "pymidi": {
             "hashes": [
@@ -233,6 +233,66 @@
             "markers": "python_version < '3.3'",
             "version": "==1.0.2"
         },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "version": "==0.17.1"
+        },
+        "gevent": {
+            "hashes": [
+                "sha256:0774babec518a24d9a7231d4e689931f31b332c4517a771e532002614e270a64",
+                "sha256:0e1e5b73a445fe82d40907322e1e0eec6a6745ca3cea19291c6f9f50117bb7ea",
+                "sha256:0ff2b70e8e338cf13bedf146b8c29d475e2a544b5d1fe14045aee827c073842c",
+                "sha256:107f4232db2172f7e8429ed7779c10f2ed16616d75ffbe77e0e0c3fcdeb51a51",
+                "sha256:14b4d06d19d39a440e72253f77067d27209c67e7611e352f79fe69e0f618f76e",
+                "sha256:1b7d3a285978b27b469c0ff5fb5a72bcd69f4306dbbf22d7997d83209a8ba917",
+                "sha256:1eb7fa3b9bd9174dfe9c3b59b7a09b768ecd496debfc4976a9530a3e15c990d1",
+                "sha256:2711e69788ddb34c059a30186e05c55a6b611cb9e34ac343e69cf3264d42fe1c",
+                "sha256:28a0c5417b464562ab9842dd1fb0cc1524e60494641d973206ec24d6ec5f6909",
+                "sha256:3249011d13d0c63bea72d91cec23a9cf18c25f91d1f115121e5c9113d753fa12",
+                "sha256:44089ed06a962a3a70e96353c981d628b2d4a2f2a75ea5d90f916a62d22af2e8",
+                "sha256:4bfa291e3c931ff3c99a349d8857605dca029de61d74c6bb82bd46373959c942",
+                "sha256:50024a1ee2cf04645535c5ebaeaa0a60c5ef32e262da981f4be0546b26791950",
+                "sha256:53b72385857e04e7faca13c613c07cab411480822ac658d97fd8a4ddbaf715c8",
+                "sha256:74b7528f901f39c39cdbb50cdf08f1a2351725d9aebaef212a29abfbb06895ee",
+                "sha256:7d0809e2991c9784eceeadef01c27ee6a33ca09ebba6154317a257353e3af922",
+                "sha256:896b2b80931d6b13b5d9feba3d4eebc67d5e6ec54f0cf3339d08487d55d93b0e",
+                "sha256:8d9ec51cc06580f8c21b41fd3f2b3465197ba5b23c00eb7d422b7ae0380510b0",
+                "sha256:9f7a1e96fec45f70ad364e46de32ccacab4d80de238bd3c2edd036867ccd48ad",
+                "sha256:ab4dc33ef0e26dc627559786a4fba0c2227f125db85d970abbf85b77506b3f51",
+                "sha256:d1e6d1f156e999edab069d79d890859806b555ce4e4da5b6418616322f0a3df1",
+                "sha256:d752bcf1b98174780e2317ada12013d612f05116456133a6acf3e17d43b71f05",
+                "sha256:e5bcc4270671936349249d26140c267397b7b4b1381f5ec8b13c53c5b53ab6e1"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:000546ad01e6389e98626c1367be58efa613fa82a1be98b0c6fc24b563acc6d0",
+                "sha256:0d48200bc50cbf498716712129eef819b1729339e34c3ae71656964dac907c28",
+                "sha256:23d12eacffa9d0f290c0fe0c4e81ba6d5f3a5b7ac3c30a5eaf0126bf4deda5c8",
+                "sha256:37c9ba82bd82eb6a23c2e5acc03055c0e45697253b2393c9a50cef76a3985304",
+                "sha256:51503524dd6f152ab4ad1fbd168fc6c30b5795e8c70be4410a64940b3abb55c0",
+                "sha256:8041e2de00e745c0e05a502d6e6db310db7faa7c979b3a5877123548a4c0b214",
+                "sha256:81fcd96a275209ef117e9ec91f75c731fa18dcfd9ffaa1c0adbdaa3616a86043",
+                "sha256:853da4f9563d982e4121fed8c92eea1a4594a2299037b3034c3c898cb8e933d6",
+                "sha256:8b4572c334593d449113f9dc8d19b93b7b271bdbe90ba7509eb178923327b625",
+                "sha256:9416443e219356e3c31f1f918a91badf2e37acf297e2fa13d24d1cc2380f8fbc",
+                "sha256:9854f612e1b59ec66804931df5add3b2d5ef0067748ea29dc60f0efdcda9a638",
+                "sha256:99a26afdb82ea83a265137a398f570402aa1f2b5dfb4ac3300c026931817b163",
+                "sha256:a19bf883b3384957e4a4a13e6bd1ae3d85ae87f4beb5957e35b0be287f12f4e4",
+                "sha256:a9f145660588187ff835c55a7d2ddf6abfc570c2651c276d3d4be8a2766db490",
+                "sha256:ac57fcdcfb0b73bb3203b58a14501abb7e5ff9ea5e2edfa06bb03035f0cff248",
+                "sha256:bcb530089ff24f6458a81ac3fa699e8c00194208a724b644ecc68422e1111939",
+                "sha256:beeabe25c3b704f7d56b573f7d2ff88fc99f0138e43480cecdfcaa3b87fe4f87",
+                "sha256:d634a7ea1fc3380ff96f9e44d8d22f38418c1c381d5fac680b272d7d90883720",
+                "sha256:d97b0661e1aead761f0ded3b769044bb00ed5d33e1ec865e891a8b128bf7c656"
+            ],
+            "markers": "platform_python_implementation == 'CPython'",
+            "version": "==0.4.15"
+        },
         "mock": {
             "hashes": [
                 "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
@@ -252,17 +312,17 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
-                "sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387"
+                "sha256:8257baf496c8522437e8a6cfe0f15e00aedc6c0e0e7c9d55eeeeab31e0853843",
+                "sha256:8c361cc353d988e4f5b998555c88098b9d5964c2e11acf7b0d21925a66bb5824"
             ],
-            "version": "==5.1.1"
+            "version": "==5.1.3"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "six": {
             "hashes": [

--- a/floor/Pipfile.lock
+++ b/floor/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "792874bb31dbf6b3e33eef597f78082dd9acfddadc82d0ab0be4453c2000cb48"
+            "sha256": "e5badabdbdd869e9327887ab2f8462afbe4718fb5654fc7d38bccd2f7eec9263"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "2.7"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -44,14 +42,6 @@
             ],
             "index": "pypi",
             "version": "==0.2.1"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.3'",
-            "version": "==1.0.2"
         },
         "future": {
             "hashes": [
@@ -206,10 +196,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
+                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.2"
         }
     },
     "develop": {
@@ -224,14 +214,6 @@
             ],
             "index": "pypi",
             "version": "==0.3.11"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.3'",
-            "version": "==1.0.2"
         },
         "future": {
             "hashes": [

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from builtins import range
+from builtins import object
 import time
 import logging
 from collections import OrderedDict
@@ -71,7 +73,7 @@ class Controller(object):
 
     def _iter_enabled_layers(self):
         """Returns an iterable of all enabled layers."""
-        return filter(lambda layer: layer.is_enabled(), self.layers.values())
+        return [layer for layer in list(self.layers.values()) if layer.is_enabled()]
 
     def set_fps(self, fps):
         self.fps = fps
@@ -172,7 +174,7 @@ class Controller(object):
                     composited_leds[idx] = current_pixel
             last_leds = current_leds
 
-        leds = map(lambda pixel: map(lambda color: color * self.brightness, pixel), composited_leds)
+        leds = [[color * self.brightness for color in pixel] for pixel in composited_leds]
         self.driver.set_leds(leds)
 
     @profile()

--- a/floor/floor/controller/layout.py
+++ b/floor/floor/controller/layout.py
@@ -1,3 +1,4 @@
+from builtins import object
 import json
 
 

--- a/floor/floor/controller/midi/mapping.py
+++ b/floor/floor/controller/midi/mapping.py
@@ -61,7 +61,7 @@ class MidiMapping(object):
 
     def to_json(self):
         mappings_list = []
-        for command, func in self.mappings.iteritems():
+        for command, func in self.mappings.items():
             mappings_list.append({
                 'command': command,
                 'function': func.name,

--- a/floor/floor/controller/playlist.py
+++ b/floor/floor/controller/playlist.py
@@ -1,3 +1,4 @@
+from builtins import object
 import json
 from time import time
 import logging

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from builtins import str
+from builtins import object
 import logging
 
 

--- a/floor/floor/controller/test.py
+++ b/floor/floor/controller/test.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import object
 import importlib
 
 

--- a/floor/floor/controller/test.py
+++ b/floor/floor/controller/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import importlib
 
 
@@ -9,7 +10,7 @@ class Test(object):
         try:
             module = importlib.import_module("floor.driver.{}".format(driver_name))
         except ImportError as e:
-            print "Error: Driver '{}' does not exist or could not be loaded: {}".format(driver_name, e)
+            print("Error: Driver '{}' does not exist or could not be loaded: {}".format(driver_name, e))
             raise
 
         self.driver = getattr(module, driver_name.title())({})

--- a/floor/floor/driver/__init__.py
+++ b/floor/floor/driver/__init__.py
@@ -1,1 +1,2 @@
-from base import Base
+from __future__ import absolute_import
+from .base import Base

--- a/floor/floor/driver/base.py
+++ b/floor/floor/driver/base.py
@@ -1,5 +1,7 @@
 
 
+from builtins import range
+from builtins import object
 class Base(object):
 
     def __init__(self, driver_args):

--- a/floor/floor/driver/devserver.py
+++ b/floor/floor/driver/devserver.py
@@ -1,3 +1,4 @@
+from builtins import map
 from gevent import monkey
 monkey.patch_all()
 
@@ -97,7 +98,7 @@ class Devserver(Base):
         return (color_value / float(COLOR_MAXIMUM)) * 256.0
 
     def send_data(self):
-        leds = [map(self.rescale_color_value, pixel) for pixel in self.leds]
+        leds = [list(map(self.rescale_color_value, pixel)) for pixel in self.leds]
         message = {
             "event": "leds",
             "payload": leds,
@@ -109,5 +110,5 @@ class Devserver(Base):
 
     def get_weights(self):
         now = time.time()
-        values = map(lambda t: 1 if (now - t) <= WEIGHT_ON_SECONDS else 0, FAKE_WEIGHTS)
+        values = [1 if (now - t) <= WEIGHT_ON_SECONDS else 0 for t in FAKE_WEIGHTS]
         return values

--- a/floor/floor/driver/raspberry.py
+++ b/floor/floor/driver/raspberry.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 import importlib
 import logging
 
-from base import Base
+from .base import Base
 from floor.util.serial_read import SerialRead
 
 logger = logging.getLogger('raspberry')

--- a/floor/floor/driver/raspberry.py
+++ b/floor/floor/driver/raspberry.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import importlib
 import logging
 

--- a/floor/floor/processor/__init__.py
+++ b/floor/floor/processor/__init__.py
@@ -16,7 +16,7 @@ def _import_all():
     pwd = os.path.dirname(__file__)
     for filename in glob(os.path.join(pwd, '*.py')):
         name, ext = os.path.splitext(os.path.basename(filename))
-        __import__(name, globals(), locals())
+        __import__('floor.processor.{}'.format(name), globals(), locals())
 
 
 def all_processors():

--- a/floor/floor/processor/balls.py
+++ b/floor/floor/processor/balls.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import random
 import math
 

--- a/floor/floor/processor/base.py
+++ b/floor/floor/processor/base.py
@@ -3,11 +3,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from builtins import range
+from builtins import object
 import logging
 import colorsys
 import sys
 
 from floor.processor.constants import COLOR_MAXIMUM
+from future.utils import with_metaclass
 
 
 class ProcessorRegistry(type):
@@ -28,7 +31,7 @@ class ProcessorRegistry(type):
         return new_class
 
 
-class RenderContext:
+class RenderContext(object):
     """An object that a `Controller` will pass to `Processor.get_next_frame`.
 
     This class is how the `Controller` passes state to the `Processor`. As such,
@@ -41,9 +44,7 @@ class RenderContext:
         self.bpm = bpm
 
 
-class Base(object):
-    __metaclass__ = ProcessorRegistry
-
+class Base(with_metaclass(ProcessorRegistry, object)):
     CONTROLS = []
 
     FLOOR_WIDTH = 8

--- a/floor/floor/processor/chachacha.py
+++ b/floor/floor/processor/chachacha.py
@@ -1,3 +1,4 @@
+from builtins import range
 import collections
 import itertools
 
@@ -16,7 +17,7 @@ COLORS = [RED, YELLOW, GREEN, WHITE]
 # Pre-render the boxes.
 LINES = []
 for color in COLORS:
-    for i in xrange(2):
+    for i in range(2):
         LINES.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
         LINES.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
         LINES.append([BLACK, BLACK, color, color, BLACK, BLACK, color, color])

--- a/floor/floor/processor/color_wash.py
+++ b/floor/floor/processor/color_wash.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.processor.constants import COLOR_MAXIMUM

--- a/floor/floor/processor/electricity.py
+++ b/floor/floor/processor/electricity.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import math
 import random
 import logging
@@ -49,7 +51,7 @@ class Electricity(Base):
 
         self.arcs = new_arcs
 
-        for arc in self.arcs.values():
+        for arc in list(self.arcs.values()):
             self.apply_arc(arc)
 
         return self.pixels

--- a/floor/floor/processor/fire.py
+++ b/floor/floor/processor/fire.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import random
 import colorsys
 import math

--- a/floor/floor/processor/fishies.py
+++ b/floor/floor/processor/fishies.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 import time
 
@@ -64,7 +65,7 @@ class Fishies(Base):
         next_time = context.clock
         d_time = next_time - self.last_time
 
-        for index in xrange(len(self.fishies)):
+        for index in range(len(self.fishies)):
             fish = self.fishies[index]
             chance = random.random()
             if d_time > 0.2:
@@ -72,7 +73,7 @@ class Fishies(Base):
                 self.last_time = next_time
             self.pixels[fish['y']*8 + fish['x']] = fish['c']
 
-        for index in xrange(len(self.pixels)):
+        for index in range(len(self.pixels)):
             px = self.pixels[index]
             px = color.scale_color(px, 0.7)
             self.pixels[index] = px

--- a/floor/floor/processor/flash_bang.py
+++ b/floor/floor/processor/flash_bang.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 import math
 

--- a/floor/floor/processor/heat_step.py
+++ b/floor/floor/processor/heat_step.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 

--- a/floor/floor/processor/hyperspace.py
+++ b/floor/floor/processor/hyperspace.py
@@ -1,3 +1,4 @@
+from builtins import range
 import time
 import math
 

--- a/floor/floor/processor/kaleidoscope.py
+++ b/floor/floor/processor/kaleidoscope.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 
 from floor.processor.base import Base

--- a/floor/floor/processor/land_mines.py
+++ b/floor/floor/processor/land_mines.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 import math
 
@@ -70,7 +71,7 @@ class LandMines(Base):
         time_delta = 0.1
         velocity = 0.0003 * COLOR_MAXIMUM
         live_mines = []
-        for index in xrange(len(self.mines)):
+        for index in range(len(self.mines)):
             mine = self.mines[index]
             mine['t'] -= time_delta
             delta_time = life_time - mine['t']

--- a/floor/floor/processor/life.py
+++ b/floor/floor/processor/life.py
@@ -1,3 +1,4 @@
+from builtins import range
 import datetime
 
 from floor.processor.base import Base

--- a/floor/floor/processor/line_slam.py
+++ b/floor/floor/processor/line_slam.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import colorsys
 import math
 

--- a/floor/floor/processor/line_slam.py
+++ b/floor/floor/processor/line_slam.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import colorsys
 import math
 
@@ -27,7 +28,7 @@ class LineSlam(Base):
         elif self.stage == 2:
             pixels = self.stage_2()
         else:
-            print "-- reset"
+            print("-- reset")
             self.reset_stage()
             pixels = self.PIXELS_ALL_OFF
 

--- a/floor/floor/processor/message.py
+++ b/floor/floor/processor/message.py
@@ -1,3 +1,4 @@
+from builtins import range
 import os.path
 import colorsys
 import importlib

--- a/floor/floor/processor/processor_test.py
+++ b/floor/floor/processor/processor_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from builtins import range
 from freezegun import freeze_time
 import time
 import datetime
@@ -31,7 +32,7 @@ def test_run_all_processors():
         with freeze_time('Jan 1, 2001') as fake_time:
             now = time.time()
             instance = cls()
-            for i in xrange(num_frames):
+            for i in range(num_frames):
                 context = RenderContext(
                     clock=now,
                     downbeat=0,
@@ -42,11 +43,11 @@ def test_run_all_processors():
                 fake_time.tick(delta=clock_time_per_frame)
 
     processors = processor.all_processors()
-    for processor_name, cls in processors.iteritems():
+    for processor_name, cls in processors.items():
         yield run_test, processor_name, cls
 
 
 class ProcessorTest(TestCase):
     def test_all_processors_excludes_base(self):
         processors = processor.all_processors()
-        self.assert_(BaseProcessor not in processors.values())
+        self.assert_(BaseProcessor not in list(processors.values()))

--- a/floor/floor/processor/pulsar.py
+++ b/floor/floor/processor/pulsar.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 
 from floor.processor.base import Base

--- a/floor/floor/processor/random_decay.py
+++ b/floor/floor/processor/random_decay.py
@@ -1,3 +1,4 @@
+from builtins import range
 import random
 
 from floor.processor.base import Base

--- a/floor/floor/processor/raver_plaid.py
+++ b/floor/floor/processor/raver_plaid.py
@@ -1,3 +1,4 @@
+from builtins import range
 import math
 
 from floor.processor.base import Base

--- a/floor/floor/processor/simple_step.py
+++ b/floor/floor/processor/simple_step.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.processor.constants import COLOR_MAXIMUM

--- a/floor/floor/processor/spiral.py
+++ b/floor/floor/processor/spiral.py
@@ -1,3 +1,4 @@
+from builtins import range
 import collections
 import colorsys
 

--- a/floor/floor/processor/stripes.py
+++ b/floor/floor/processor/stripes.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import random
 
 from floor.processor.base import Base
@@ -65,7 +67,7 @@ class Stripes(Base):
         return pixels
 
 
-class Stripe:
+class Stripe(object):
 
     def __init__(self, gradient, speed, direction):
         self.gradient = gradient

--- a/floor/floor/processor/test.py
+++ b/floor/floor/processor/test.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.processor.constants import COLOR_MAXIMUM

--- a/floor/floor/processor/test_step.py
+++ b/floor/floor/processor/test_step.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.util import color_utils

--- a/floor/floor/processor/throbber.py
+++ b/floor/floor/processor/throbber.py
@@ -1,3 +1,4 @@
+from builtins import range
 from floor.processor.base import Base
 
 

--- a/floor/floor/processor/utils.py
+++ b/floor/floor/processor/utils.py
@@ -1,4 +1,5 @@
 
+from builtins import object
 BLANK_FRAME = [(0, 0, 0)] * 64
 
 

--- a/floor/floor/processor/utils_test.py
+++ b/floor/floor/processor/utils_test.py
@@ -1,3 +1,4 @@
+from builtins import range
 import datetime
 import mock
 from unittest import TestCase
@@ -25,7 +26,7 @@ class UtilsTestCase(TestCase):
 
         # Any number of subsequent calls, without advancing time, will not
         # call the underlying wrapped function.
-        for i in xrange(100):
+        for i in range(100):
             ret = fn(processor, RenderContext(clock, downbeat, weights, bpm))
             self.assertEqual('a', ret)
             self.assertEqual(1, wrapped_fn.call_count)

--- a/floor/floor/processor/zap.py
+++ b/floor/floor/processor/zap.py
@@ -1,3 +1,4 @@
+from builtins import range
 import collections
 
 from floor.processor.base import Base
@@ -17,7 +18,7 @@ def gradient(color, steps=4):
     """Fade this color to white."""
     ret = []
     denominator = float(steps - 1)
-    for step in xrange(steps):
+    for step in range(steps):
         percent = step / denominator
         ret.append(tint(color, percent))
     return ret

--- a/floor/floor/server/server.py
+++ b/floor/floor/server/server.py
@@ -1,3 +1,4 @@
+from builtins import str
 import os
 import time
 import threading
@@ -52,7 +53,7 @@ def view_tempo(bpm, downbeat):
 
 def view_processors(processors):
     ret = {}
-    for k, v in processors.iteritems():
+    for k, v in processors.items():
         ret[k] = {
             'name': k,
         }
@@ -61,7 +62,7 @@ def view_processors(processors):
 
 def view_all_layers(layers):
     result = {}
-    for k, v in layers.items():
+    for k, v in list(layers.items()):
         if k == 'playlist':
             continue
         result[k] = view_processor_layer(v)

--- a/floor/floor/util/color_utils.py
+++ b/floor/floor/util/color_utils.py
@@ -3,6 +3,7 @@ Helper functions to make color manipulations easier
 """
 
 from __future__ import division
+from builtins import range
 import math
 import random
 from floor.processor.constants import COLOR_MAXIMUM
@@ -140,7 +141,7 @@ palettes = {
     'linoleum': ['d33f49', 'd7c0d0', 'eff0d1', '77ba99', '806c89'],
     'wedding1': ['f8aeaa', 'abaab2', 'f5927b']
 }
-palette_keys = palettes.keys()
+palette_keys = list(palettes.keys())
 palettes_length = len(palette_keys)
 
 

--- a/floor/floor/util/easing.py
+++ b/floor/floor/util/easing.py
@@ -1,3 +1,4 @@
+from builtins import object
 import math
 import time
 

--- a/floor/floor/util/serial_read.py
+++ b/floor/floor/util/serial_read.py
@@ -1,7 +1,10 @@
+from builtins import chr
+from builtins import range
+from builtins import object
 import serial
 
 
-class SerialRead:
+class SerialRead(object):
 
     packets = 64
     packet_bytes = 2

--- a/floor/floor/util/simple_profile.py
+++ b/floor/floor/util/simple_profile.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import os
 import logging

--- a/floor/floor/util/simple_profile.py
+++ b/floor/floor/util/simple_profile.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import object
 import time
 import os
 import logging


### PR DESCRIPTION
Mechanical & mostly automatic changes to support Python 3.

Individual commits show command used to generate changes. This gets the the project building, running, and passing tests under python 3.

In a future change, I'd recommend we make the project python 3 only, as python 2 is EOL after 2019 & it would eliminate a needless opportunity for variation in environments. As part of that, we would review & remove all automatically-applied uses of `future` -- for example, many of the `old_div` sites here may be unnecessary.