### PR TITLE
server ui: rework layout

### DIFF
--- a/floor/floor/driver/devserver.py
+++ b/floor/floor/driver/devserver.py
@@ -14,7 +14,7 @@ import gevent
 from geventwebsocket.handler import WebSocketHandler
 
 from flask import Flask
-from flask import render_template
+from flask import render_template, request
 from flask_sockets import Sockets
 
 from floor.driver.base import Base
@@ -57,8 +57,11 @@ def echo_socket(ws):
 
 
 @app.route('/')
-def hello():
-    return render_template('index.html')
+def devserver_main():
+    # "Embedded" mode means the devserver is being shown in an iframe, eg
+    # from the control server. The template will hide some things in this mode.
+    is_embedded = request.args.get('is_embedded', '') == 'true'
+    return render_template('index.html', is_embedded=is_embedded)
 
 
 def sender():

--- a/floor/floor/driver/devserver/index.html
+++ b/floor/floor/driver/devserver/index.html
@@ -2,29 +2,55 @@
 <head>
 <title>dance floor devserver</title>
 <style>
-body {
-  color: #ccc;
-  background: #000;
-  font-family: Arial;
-}
-h1 small {
-  font-size: 0.5em;
-  color: #777;
-}
-.pixel {
-  width: 48px;
-  height: 48px;
-  padding: 2px;
-  display: inline-block;
-  border: 1px solid #222;
-}
+  body {
+    color: #ccc;
+    background: #000;
+    font-family: Arial;
+    width: 100%;
+    height: 100%;
+    padding: 0px;
+    margin: 0px;
+  }
+
+  h1 small {
+    font-size: 0.5em;
+    color: #777;
+  }
+
+  #content {
+    display: flex;
+    height: 100%;
+    width: 100%;
+    justify-content: center;
+  }
+
+  #dance-floor {
+  }
+
+  .pixel {
+    width: 10vh;
+    height: 10vh;
+    padding: 0.5vh;
+    display: inline-block;
+    border: 0.2vh solid #222;
+  }
+
+  .hide-if-embedded {
+    {% if is_embedded %}
+    display: none;
+    {% endif %}
+  }
 </style>
 </head>
 <body>
 
-<h1>Let's Dance! <small id="socket-status"></small></h1>
+<div class="hide-if-embedded">
+  <h1>Let's Dance! <small id="socket-status"></small></h1>
+</div>
 
-<div id="dance-floor"></div>
+<div id="content">
+  <div id="dance-floor"></div>
+</div>
 
 <script>
   var reconnectHandle;

--- a/floor/floor/server/server.py
+++ b/floor/floor/server/server.py
@@ -18,7 +18,10 @@ app.controller = None  # type: Controller
 
 @app.route('/')
 def main():
-    return render_template('index.html')
+    # TODO(mikey): Brittle.
+    hostname = request.host.split(':')[0]
+    devserver_url = 'http://{}:1979'.format(hostname)
+    return render_template('index.html', devserver_url=devserver_url)
 
 
 @app.route('/layout')

--- a/floor/floor/server/static/page.css
+++ b/floor/floor/server/static/page.css
@@ -7,12 +7,28 @@ body {
 .playlist-button {
   min-height: 48px;
 }
+
+#playlist {
+  max-height: 200px;
+  overflow: scroll;
+}
+
 #tapper {
   margin-top: 24px;
   min-height: 128px;
 }
+
 #bpm-status {
   font-style: italic;
+}
+
+#floor-preview {
+  
+}
+
+#floor-preview-frame {
+  width: 100%;
+  border: 1px solid #ccc;
 }
 
 div.tile {

--- a/floor/floor/server/templates/index.html
+++ b/floor/floor/server/templates/index.html
@@ -2,120 +2,164 @@
 {% block body %}
 <div class="container">
   <div class="row">
-    <div class="col-sm-6">
-      <h2>Now Playing</h2>
-      <div id="playlist"></div>
-    </div>
-
-    <div class="col-sm-6">
-      <h2>Control Panel</h2>
-      <div id="controls">
-        <div class="btn-group btn-group-justified" role="group" aria-label="...">
-          <div class="btn-group" role="group">
-            <button class="btn btn-default btn-block playlist-button" id="previous-button">
-              <span class="glyphicon glyphicon-fast-backward" aria-hidden="true"></span>
-            </button>
-          </div>
-          <div class="btn-group" role="group">
-            <button class="btn btn-default btn-block playlist-button" id="stay-button">
-              <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
-            </button>
-          </div>
-          <div class="btn-group" role="group">
-            <button class="btn btn-default btn-block playlist-button" id="next-button">
-              <span class="glyphicon glyphicon-fast-forward" aria-hidden="true"></span>
-            </button>
-          </div>
+    <div class="col-md-4">
+      <!-- Playlist controls-->
+      <div>
+        <h4>Playlist</h4>
+        <div class="well well-sm">  
+          <div id="playlist"></div>
         </div>
         <br/>
-        <div>
-          <button class="btn btn-default btn-block playlist-button" id="stop-button">
-            <span class="glyphicon glyphicon-stop" aria-hidden="true"></span> Stop
-          </button>
-          <button class="btn btn-default btn-block playlist-button" id="start-button" style="display: none">
-            <span class="glyphicon glyphicon-play" aria-hidden="true"></span> Start
-          </button>
-        </div>
-        <div>
-          <br/>
-          <select name="brightness" id="brightness" class="form-control select">
-            <option value="1.0">Brightness: 100%</option>
-            <option value="0.9">Brightness: 90%</option>
-            <option value="0.8">Brightness: 80%</option>
-            <option value="0.7">Brightness: 70%</option>
-            <option value="0.6">Brightness: 60%</option>
-            <option value="0.5">Brightness: 50%</option>
-            <option value="0.4">Brightness: 40%</option>
-            <option value="0.3">Brightness: 30%</option>
-            <option value="0.2">Brightness: 20%</option>
-            <option value="0.1">Brightness: 10%</option>
-            <option value="0.0">Brightness: 0%</option>
-          </select>
-        </div>
-      </div>
-
-      <hr/>
-      <h4>Advanced Disco Zone <span class="glyphicon glyphicon-fire" aria-hidden="true"></span></h4>
-
-      <button class="btn btn-default btn-block" id="tapper">
-        Tap BPM
-      </button>
-      <p class="text-muted" id="bpm-status">
-        <form class="form-inline text-center">
-          <div class="form-group">
-            <div class="input-group">
-              <input id="bpm" type="number" step="0.1" min="40.0" max="220.0"
-                class="form-control" placeholder="120.0">
-              <div class="input-group-addon">BPM</div>
+        <div id="controls">
+          <div class="btn-group btn-group-justified" role="group" aria-label="...">
+            <div class="btn-group" role="group">
+              <button class="btn btn-default btn-block playlist-button" id="previous-button">
+                <span class="glyphicon glyphicon-fast-backward" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="btn-group" role="group">
+              <button class="btn btn-default btn-block playlist-button" id="stay-button">
+                <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="btn-group" role="group">
+              <button class="btn btn-default btn-block playlist-button" id="next-button">
+                <span class="glyphicon glyphicon-fast-forward" aria-hidden="true"></span>
+              </button>
             </div>
           </div>
-        </form>
-      </p>
-
-      <!-- BPM Nudger -->
-      <div class="btn-group btn-group-justified" role="group" aria-label="...">
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" id="bpm-nudge-left">
-            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-            Slower
-          </button>
-        </div>
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" disabled>
-            BPM
-          </button>
-        </div>
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" id="bpm-nudge-right">
-            Faster
-            <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-          </button>
+          <br/>
+          <div>
+            <button class="btn btn-default btn-block playlist-button" id="stop-button">
+              <span class="glyphicon glyphicon-stop" aria-hidden="true"></span> Stop
+            </button>
+            <button class="btn btn-default btn-block playlist-button" id="start-button" style="display: none">
+              <span class="glyphicon glyphicon-play" aria-hidden="true"></span> Start
+            </button>
+          </div>
         </div>
       </div>
-
-      <p></p>
-
-      <!-- Downbeat Nudger -->
-      <div class="btn-group btn-group-justified" role="group" aria-label="...">
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" id="downbeat-nudge-left">
-            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-            Earlier
-          </button>
-        </div>
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" disabled>
-            Downbeat
-          </button>
-        </div>
-        <div class="btn-group" role="group">
-          <button type="button" class="btn btn-default" id="downbeat-nudge-right">
-            Later
-            <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-          </button>
-        </div>
+      
+      <!-- System Brightness -->
+      <br/>
+      <div>
+        <select name="brightness" id="brightness" class="form-control select">
+          <option value="1.0">Brightness: 100%</option>
+          <option value="0.9">Brightness: 90%</option>
+          <option value="0.8">Brightness: 80%</option>
+          <option value="0.7">Brightness: 70%</option>
+          <option value="0.6">Brightness: 60%</option>
+          <option value="0.5">Brightness: 50%</option>
+          <option value="0.4">Brightness: 40%</option>
+          <option value="0.3">Brightness: 30%</option>
+          <option value="0.2">Brightness: 20%</option>
+          <option value="0.1">Brightness: 10%</option>
+          <option value="0">Brightness: 0%</option>
+        </select>
+  
       </div>
     </div>
+
+    <div class="col-md-4">
+      <div>
+        <!-- System BPM info -->
+        <h4 class="text-center">Main</h4>
+        <p class="text-muted" id="bpm-status">
+            <form class="form-inline text-center">
+              <div class="form-group">
+                <div class="input-group">
+                  <input id="bpm" type="number" step="0.1" min="40.0" max="220.0"
+                    class="form-control" placeholder="120.0">
+                  <div class="input-group-addon">BPM</div>
+                </div>
+              </div>
+            </form>
+          </p>
+  
+        <button class="btn btn-default btn-block" id="tapper">
+          Tap BPM
+        </button>
+  
+        <!-- BPM Nudger -->
+        <div class="btn-group btn-group-justified" role="group" aria-label="...">
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" id="bpm-nudge-left">
+              <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+              Slower
+            </button>
+          </div>
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" disabled>
+              BPM
+            </button>
+          </div>
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" id="bpm-nudge-right">
+              Faster
+              <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            </button>
+          </div>
+        </div>
+  
+        <p></p>
+  
+        <!-- Downbeat Nudger -->
+        <div class="btn-group btn-group-justified" role="group" aria-label="...">
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" id="downbeat-nudge-left">
+              <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+              Earlier
+            </button>
+          </div>
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" disabled>
+              Downbeat
+            </button>
+          </div>
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-default" id="downbeat-nudge-right">
+              Later
+              <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            </button>
+          </div>
+        </div>
+    
+
+      </div>
+
+      <div id="floor-preview">
+        <iframe id="floor-preview-frame" src="{{ devserver_url }}?is_embedded=true"></iframe>
+      </div>
+    </div>
+  
+    <div class="col-md-4">
+      <div>
+       <h4>Layers</h4>
+
+       <div class="well well-sm">
+        <h5>Overlay 1</h5>
+          <form class="form-inline">
+            <div class="form-group" style="width: 100%;">
+              <div class="input-group" style="width: 100%;" id="overlay1_controls">
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="well well-sm">
+          <h5>Overlay 2</h5>
+            <form class="form-inline">
+              <div class="form-group" style="width: 100%;">
+                <div class="input-group" style="width: 100%;" id="overlay2_controls">
+                </div>
+              </div>
+            </form>
+          </div>
+      
+    
+      </div>
+    </div>
+
   </div>
 
 </div><!-- /.container -->


### PR DESCRIPTION
(This PR is based on #47; only the newest commit is unique.)

Reworks the server UI to more closely match the "hardware controller"-style layout we tossed around over the holiday break. It also adds a live preview of the devserver, which is at least pretty convenient when developing.

This will of course need further iteration, and as the complexity of the web ui goes up, I'm wishing more and more for modern JS features and a framework like react. Would probably make sense to break the ui into its own standalone project if we get to that point; obviously, putting that off for now..