### PR TITLE
Add ranged input control to api & web ui; example processor use

### DIFF
--- a/floor/config/midi_maps/akai-apcmini.json
+++ b/floor/config/midi_maps/akai-apcmini.json
@@ -31,19 +31,19 @@
     },
     {
       "command": ["control_mode_change", 48],
-      "function": "ranged_value_1"
+      "function": "playlist_ranged_value_1"
     },
     {
       "command": ["control_mode_change", 49],
-      "function": "ranged_value_2"
+      "function": "playlist_ranged_value_2"
     },
     {
       "command": ["control_mode_change", 50],
-      "function": "ranged_value_3"
+      "function": "playlist_ranged_value_3"
     },
     {
       "command": ["control_mode_change", 51],
-      "function": "ranged_value_4"
+      "function": "playlist_ranged_value_4"
     },
     {
       "command": ["note_on", "G#3"],

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -141,7 +141,6 @@ class Controller(object):
             return
 
         self.init_loop()
-        self.prepare()
         self.generate_frame()
         self.transfer_data()
         self.delay()
@@ -149,11 +148,6 @@ class Controller(object):
     @profile()
     def init_loop(self):
         self.frame_start = self.clocksource.time()
-
-    @profile()
-    def prepare(self):
-        for layer in self._iter_enabled_layers():
-            layer.prepare()
 
     @profile()
     def generate_frame(self):

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -151,15 +151,17 @@ class Controller(object):
 
     @profile()
     def generate_frame(self):
-        context = RenderContext(
-            clock=self.frame_start,
-            downbeat=self.downbeat,
-            weights=self.get_weights(),
-            bpm=self.bpm,
-        )
-
+        weights = self.get_weights()
         composited_leds = [(0, 0, 0)] * 64
         for layer in self._iter_enabled_layers():
+            context = RenderContext(
+                clock=self.frame_start,
+                downbeat=self.downbeat,
+                weights=weights,
+                bpm=self.bpm,
+                ranged_values=layer.ranged_values,
+                switches=layer.switches,
+            )
             current_leds = layer.render(context)
             if not current_leds:
                 continue

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -96,12 +96,22 @@ MidiFunctions.add('set_brightness',
                   callback=lambda controller, value: controller.set_brightness(value/127.0),
                   help_text='Adjust the max brightness of the floor')
 
-# Add a number of ranged values, likely faders or knobs, that can be used within processor code
-# to tweak parameters.
-for idx in range(0, 4):
-    MidiFunctions.add('ranged_value_{}'.format(idx+1),
-                      callback=lambda controller, value, i=idx: controller.handle_ranged_value(i, value),
-                      help_text='A generic ranged value for adjusting processor parameters')
+# Add events to send ranged values and switches to each render layer.
+for event_base_name in (
+    'playlist_ranged_value',
+    'overlay1_ranged_value',
+    'overlay2_ranged_value',
+    'playlist_switch',
+    'overlay1_switch',
+    'overlay2_switch'):
+    for idx in range(0, 4):
+        event_name = '{}_{}'.format(event_base_name, idx+1)
+        def callback(controller, value, event_base_name=event_base_name, i=idx):
+            controller.handle_input_event(event_base_name, i, value)
+        MidiFunctions.add(event_name,
+                        callback=callback,
+                        help_text='An event for adjusting processor parameters')
+
 
 # Setup methods for floor foot presses
 for idx in range(1, 65):

--- a/floor/floor/controller/midi_test.py
+++ b/floor/floor/controller/midi_test.py
@@ -18,7 +18,8 @@ DEMO_MAPPING = MidiMapping(name='demo', mappings={
     (COMMAND_NOTE_ON, 'C4'): MidiFunctions.playlist_previous,
     (COMMAND_NOTE_ON, 'C#-1', 127): MidiFunctions.playlist_stay,
     (COMMAND_CONTROL_MODE_CHANGE, 21, 127): MidiFunctions.playlist_stop,
-    (COMMAND_CONTROL_MODE_CHANGE, 48): MidiFunctions.ranged_value_2,
+    (COMMAND_CONTROL_MODE_CHANGE, 48): MidiFunctions.playlist_ranged_value_2,
+    (COMMAND_NOTE_ON, 'C2'): MidiFunctions.overlay2_switch_3,
 })
 
 
@@ -94,11 +95,18 @@ class MidiManagerTestCase(TestCase):
         self.inject_control_mode_change(21, 127)
         self.assertEqual(1, self.controller.playlist.stop_playlist.call_count)
 
-        self.assertEqual(0, self.controller.handle_ranged_value.call_count)
+        self.assertEqual(0, self.controller.handle_input_event.call_count)
         self.inject_control_mode_change(48, 99)
-        self.assertEqual(1, self.controller.handle_ranged_value.call_count)
-        self.controller.handle_ranged_value.assert_has_calls([
-            mock.call(1, 99),
+        self.assertEqual(1, self.controller.handle_input_event.call_count)
+        self.controller.handle_input_event.assert_has_calls([
+            mock.call('playlist_ranged_value', 1, 99),
+        ])
+
+        self.controller.handle_input_event.reset_mock()
+        self.assertEqual(0, self.controller.handle_input_event.call_count)
+        self.inject_note_on('C2', 127)
+        self.controller.handle_input_event.assert_has_calls([
+            mock.call('overlay2_switch', 2, 127),
         ])
 
     def test_note_name_translation(self):

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -46,6 +46,37 @@ class BaseRenderLayer(object):
         raise NotImplementedError
 
 
+class ProcessorRenderLayer(BaseRenderLayer):
+    """A RenderLayer that encapsulates a single Processor."""
+    def __init__(self, processor=None):
+        super(ProcessorRenderLayer, self).__init__()
+        self.processor = processor
+        self.logger = logging.getLogger(__name__)
+
+    def is_enabled(self):
+        return self.processor is not None and self.enabled
+
+    def on_ranged_value_change(self, num, val):
+        if self.processor:
+            self.processor.on_ranged_value_change(num, val)
+
+    def render(self, render_context):
+        if self.processor:
+            return self.processor.get_next_frame(render_context)
+        return None
+
+    def set_processor(self, processor):
+        self.processor = processor
+
+    def get_processor(self):
+        return self.processor
+
+    def get_processor_name(self):
+        if not self.processor:
+            return None
+        return self.processor.__class__.__name__
+
+
 class PlaylistRenderLayer(BaseRenderLayer):
     """A RenderLayer that encapsulates a Playlist."""
     def __init__(self, playlist, all_processors):
@@ -107,34 +138,3 @@ class PlaylistRenderLayer(BaseRenderLayer):
             return processor_cls(**args)
         except Exception as e:
             raise ValueError('Processor "{}" could not be created: {}'.format(name, str(e)))
-
-
-class ProcessorRenderLayer(BaseRenderLayer):
-    """A RenderLayer that encapsulates a single Processor."""
-    def __init__(self, processor=None):
-        super(ProcessorRenderLayer, self).__init__()
-        self.processor = processor
-        self.logger = logging.getLogger(__name__)
-
-    def is_enabled(self):
-        return self.processor is not None and self.enabled
-
-    def on_ranged_value_change(self, num, val):
-        if self.processor:
-            self.processor.on_ranged_value_change(num, val)
-
-    def render(self, render_context):
-        if self.processor:
-            return self.processor.get_next_frame(render_context)
-        return None
-
-    def set_processor(self, processor):
-        self.processor = processor
-
-    def get_processor(self):
-        return self.processor
-
-    def get_processor_name(self):
-        if not self.processor:
-            return None
-        return self.processor.__class__.__name__

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -7,6 +7,8 @@ from builtins import str
 from builtins import object
 import logging
 
+from floor.processor.constants import RANGED_INPUT_MAX
+
 
 class BaseRenderLayer(object):
     """Abstract class for anything that can return a frame of pixels."""
@@ -35,9 +37,9 @@ class BaseRenderLayer(object):
         
         Arguments:
             num {integer} -- The 0-indexed fader/slider number, between 0-3 inclusive
-            val {integer} -- The position value, between 0-127 inclusive
+            val {integer} -- The position value, between 0-`RANGED_INPUT_MAX` inclusive
         """
-        val = max(0, min(val, 127))
+        val = max(0, min(val, RANGED_INPUT_MAX))
         self.logger.debug('on_ranged_value_change: {} -> {}'.format(num, val))
         if num >= len(self.ranged_values):
             return

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -57,16 +57,15 @@ class PlaylistRenderLayer(BaseRenderLayer):
         self.current_processor = None
         self.current_processor_name = None
         self.current_processor_args = None
+        self.processor_render_layer = ProcessorRenderLayer()
 
     def on_ranged_value_change(self, num, val):
-        if self.current_processor:
-            self.current_processor.on_ranged_value_change(num, val)
+        return self.processor_render_layer.on_ranged_value_change(num, val)
 
     def render(self, render_context):
         self._check_playlist(render_context)
         try:
-            leds = self.current_processor.get_next_frame(render_context)
-            return leds
+            return self.processor_render_layer.render(render_context)
         except KeyboardInterrupt:
             raise
         except Exception:
@@ -95,6 +94,7 @@ class PlaylistRenderLayer(BaseRenderLayer):
         self.current_processor = self._build_processor(processor_name, processor_args)
         self.current_processor_name = processor_name
         self.current_processor_args = processor_args
+        self.processor_render_layer.set_processor(self.current_processor)
         self.logger.info("Started processor '{}'".format(processor_name))
 
     def _build_processor(self, name, args=None):

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -16,7 +16,7 @@ class BaseRenderLayer(object):
         self.enabled = True
         self.alpha = 1.0
         self.ranged_values = [0] * 4
-        self.switches = [0] * 4
+        self.switches = [False] * 4
 
     def set_enabled(self, enabled):
         self.enabled = bool(enabled)
@@ -118,6 +118,9 @@ class PlaylistRenderLayer(BaseRenderLayer):
 
     def on_switch_change(self, num, is_on):
         return self.processor_render_layer.on_switch_change(num, is_on)
+
+    def get_processor_name(self):
+        return self.processor_render_layer.get_processor_name()
 
     def render(self, render_context):
         self._check_playlist(render_context)

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -31,22 +31,30 @@ class BaseRenderLayer(object):
         self.alpha = min(1.0, max(0, alpha))
 
     def on_ranged_value_change(self, num, val):
-        val = max(0, min(val, 255))
+        """Sets the ranged input value.
+        
+        Arguments:
+            num {integer} -- The 0-indexed fader/slider number, between 0-3 inclusive
+            val {integer} -- The position value, between 0-127 inclusive
+        """
+        val = max(0, min(val, 127))
         self.logger.debug('on_ranged_value_change: {} -> {}'.format(num, val))
         if num >= len(self.ranged_values):
             return
         self.ranged_values[num] = val
 
     def on_switch_change(self, num, is_on):
+        """Sets the on/off switch value.
+
+        Arguments:
+            num {integer} -- The 0-indexed switch number, between 0-3 inclusive
+            is_on {bool} -- Whether the switch should be on or off
+        """
         is_on = bool(is_on)
         self.logger.debug('on_switch_change: {} -> {}'.format(num, is_on))
         if num >= len(self.switches):
             return
         self.switches[num] = bool(is_on)
-
-    def prepare(self):
-        """Perform any setup prior to next call of `generate_frame`."""
-        pass
 
     def render(self, render_context):
         """Return a frame of pixels
@@ -70,6 +78,7 @@ class ProcessorRenderLayer(BaseRenderLayer):
         return self.processor is not None and self.enabled
 
     def on_ranged_value_change(self, num, val):
+        """Extends the base implementation to add a callback to the current processor."""
         super(ProcessorRenderLayer, self).on_ranged_value_change(num, val)
         if self.processor:
             self.processor.on_ranged_value_change(num, val)

--- a/floor/floor/processor/chachacha.py
+++ b/floor/floor/processor/chachacha.py
@@ -2,26 +2,18 @@ from builtins import range
 import collections
 import itertools
 
-from floor.processor.base import Base
+from floor.processor.base import Base, RenderContext
 from floor.processor.utils import clocked
-from floor.processor.constants import COLOR_MAXIMUM
+from floor.util.color_utils import get_palette
+
+
+PALLETS = [
+    get_palette('rygw'),
+    get_palette('unicorns'),
+    get_palette('desert'),
+]
 
 BLACK = (0, 0, 0)
-RED = (1, 0, 0)
-YELLOW = (1, 0xf0/float(0xff), 0)
-GREEN = (0, 1, 0)
-WHITE = (1, 1, 1)
-
-COLORS = [RED, YELLOW, GREEN, WHITE]
-
-# Pre-render the boxes.
-LINES = []
-for color in COLORS:
-    for i in range(2):
-        LINES.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
-        LINES.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
-        LINES.append([BLACK, BLACK, color, color, BLACK, BLACK, color, color])
-        LINES.append([BLACK, BLACK, color, color, BLACK, BLACK, color, color])
 
 
 class ChaChaCha(Base):
@@ -29,12 +21,32 @@ class ChaChaCha(Base):
 
     def __init__(self, **kwargs):
         super(ChaChaCha, self).__init__(**kwargs)
-        self.lines = collections.deque(LINES)
+        self.pallet = None
+        self.lines = None
+        self.set_pallet(PALLETS[0])
+
+    def set_pallet(self, pallet):
+        if pallet == self.pallet:
+            return
+        self.pallet = pallet
+
+        lines = []
+        for color in self.pallet:
+            for i in range(2):
+                lines.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
+                lines.append([color, color, BLACK, BLACK, color, color, BLACK, BLACK])
+                lines.append([BLACK, BLACK, color, color, BLACK, BLACK, color, color])
+                lines.append([BLACK, BLACK, color, color, BLACK, BLACK, color, color])
+        self.lines = collections.deque(lines)
+
+    def on_ranged_value_change(self, num, value):
+        if num == RenderContext.RangedInput.WET_DRY:
+            pallet = RenderContext.ranged_selection(value, PALLETS)
+            self.set_pallet(pallet)
 
     @clocked(frames_per_beat=2)
     def get_next_frame(self, context):
         lines = list(itertools.islice(self.lines, 0, 8))
         self.lines.rotate()
-        pixels = [(pixel[0] * COLOR_MAXIMUM, pixel[1] * COLOR_MAXIMUM, pixel[2] * COLOR_MAXIMUM)
-                  for line in lines for pixel in line]
+        pixels = [pixel for line in lines for pixel in line]
         return pixels

--- a/floor/floor/processor/constants.py
+++ b/floor/floor/processor/constants.py
@@ -6,3 +6,6 @@ from __future__ import unicode_literals
 # Maximum value for any component color in a pixel. As currently defined,
 # colors have a 10-bit range of `[0, 1024]`
 COLOR_MAXIMUM = 1024
+
+# Maximum value of a ranged input.
+RANGED_INPUT_MAX = 127

--- a/floor/floor/processor/processor_test.py
+++ b/floor/floor/processor/processor_test.py
@@ -38,6 +38,8 @@ def test_run_all_processors():
                     downbeat=0,
                     weights=fake_weights,
                     bpm=120.0,
+                    ranged_values=[0] * 4,
+                    switches=[False] * 4,
                 )
                 instance.get_next_frame(context)
                 fake_time.tick(delta=clock_time_per_frame)

--- a/floor/floor/processor/utils_test.py
+++ b/floor/floor/processor/utils_test.py
@@ -18,27 +18,29 @@ class UtilsTestCase(TestCase):
         downbeat = 0
         weights = [0] * 64
         bpm = 120
+        ranged_values = [0] * 4
+        switches = [False] * 4
 
         # First call should call the underlying wrapped function.
-        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm))
+        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches))
         self.assertEqual('a', ret)
         self.assertEqual(1, wrapped_fn.call_count)
 
         # Any number of subsequent calls, without advancing time, will not
         # call the underlying wrapped function.
         for i in range(100):
-            ret = fn(processor, RenderContext(clock, downbeat, weights, bpm))
+            ret = fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches))
             self.assertEqual('a', ret)
             self.assertEqual(1, wrapped_fn.call_count)
 
         # Since we are at 120 bpm, the cache will be invalidated every 0.5 seconds,
         # so let's move time forward.
         clock += 0.4
-        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm))
+        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches))
         self.assertEqual('a', ret)
         self.assertEqual(1, wrapped_fn.call_count)
         clock += 0.1
-        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm))
+        ret = fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches))
         self.assertEqual('b', ret)
         self.assertEqual(2, wrapped_fn.call_count)
 
@@ -52,31 +54,33 @@ class UtilsTestCase(TestCase):
         downbeat = 0
         weights = [0] * 64
         bpm = 120
-        
+        ranged_values = [0] * 4
+        switches = [False] * 4
+
         # With frames_per_beat=4 instead of the default 1, we expect a new call
         # to the wrapped function every 0.125 seconds instead of every 0.5.
 
-        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(1, wrapped_fn.call_count)
 
         clock += 0.1
-        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(1, wrapped_fn.call_count)
 
         clock += 0.025
-        self.assertEqual('b', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('b', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(2, wrapped_fn.call_count)
 
         clock += 0.125
-        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(3, wrapped_fn.call_count)
 
         clock += 0.1
-        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(3, wrapped_fn.call_count)
 
         clock += 2
-        self.assertEqual('d', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('d', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(4, wrapped_fn.call_count)
 
     def test_clocked_with_frames_per_second(self):
@@ -89,26 +93,28 @@ class UtilsTestCase(TestCase):
         downbeat = 0
         weights = [0] * 64
         bpm = 1000
+        ranged_values = [0] * 4
+        switches = [False] * 4
 
-        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(1, wrapped_fn.call_count)
 
         clock += 0.5
-        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('a', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(1, wrapped_fn.call_count)
 
         clock += 0.5
-        self.assertEqual('b', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('b', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(2, wrapped_fn.call_count)
 
         clock += 1.0
-        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(3, wrapped_fn.call_count)
 
         clock += 0.1
-        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('c', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(3, wrapped_fn.call_count)
 
         clock += 1.0
-        self.assertEqual('d', fn(processor, RenderContext(clock, downbeat, weights, bpm)))
+        self.assertEqual('d', fn(processor, RenderContext(clock, downbeat, weights, bpm, ranged_values, switches)))
         self.assertEqual(4, wrapped_fn.call_count)

--- a/floor/floor/server/templates/index.html
+++ b/floor/floor/server/templates/index.html
@@ -9,7 +9,16 @@
         <div class="well well-sm">  
           <div id="playlist"></div>
         </div>
-        <br/>
+
+        <div class="well well-sm">
+          <form class="form-inline">
+            <div class="form-group" style="width: 100%;">
+              <div class="input-group" style="width: 100%;" id="playlist_controls">
+              </div>
+            </div>
+          </form>
+        </div>
+
         <div id="controls">
           <div class="btn-group btn-group-justified" role="group" aria-label="...">
             <div class="btn-group" role="group">

--- a/floor/floor/util/color_utils.py
+++ b/floor/floor/util/color_utils.py
@@ -132,13 +132,14 @@ palettes = {
     'autumn': ['8ea604', 'f5bb00', 'ec9f05', 'd76a03', 'bf3100'],
     'unicorns': ['dec5e3', 'cdedfd', 'b6dcfe', 'a9f8fb', '81f7e5'],
     'linoleum': ['d33f49', 'd7c0d0', 'eff0d1', '77ba99', '806c89'],
-    'wedding1': ['f8aeaa', 'abaab2', 'f5927b']
+    'wedding1': ['f8aeaa', 'abaab2', 'f5927b'],
+    'rygw': ['ff0000', 'ffff00', '00ff00', 'ffffff'],
 }
 palette_keys = list(palettes.keys())
 palettes_length = len(palette_keys)
 
 
-def get_palette(name, max_value):
+def get_palette(name, max_value=COLOR_MAXIMUM):
     hex_list = palettes[name]
     return [scale_color(hex_to_rgb(s), max_value/256.0) for s in hex_list]
 


### PR DESCRIPTION
This plumbs ranged value management into the web ui, and updates the `ChaChaCha` processor as a simple example of how it can be used to select a new color pallet on-the-fly.

(Depends on #51; only later changes are unique to this PR)