### PR TITLE
bugfix: fix processors which were not scaling color values

### DIFF
--- a/floor/floor/processor/animator.py
+++ b/floor/floor/processor/animator.py
@@ -2,7 +2,8 @@ import importlib
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
-
+from floor.util.color_utils import scale_color
+from floor.processor.constants import COLOR_MAXIMUM
 
 class Animator(Base):
 
@@ -28,4 +29,5 @@ class Animator(Base):
 
         self.floor_frame = (self.floor_frame + 1) % 24
 
+        pixels = [scale_color(p, COLOR_MAXIMUM / 255.0) for p in pixels]
         return pixels

--- a/floor/floor/processor/constants.py
+++ b/floor/floor/processor/constants.py
@@ -7,5 +7,8 @@ from __future__ import unicode_literals
 # colors have a 10-bit range of `[0, 1024]`
 COLOR_MAXIMUM = 1024
 
+WHITE = (COLOR_MAXIMUM, COLOR_MAXIMUM, COLOR_MAXIMUM)
+BLACK = (0, 0, 0)
+
 # Maximum value of a ranged input.
 RANGED_INPUT_MAX = 127

--- a/floor/floor/processor/fishies.py
+++ b/floor/floor/processor/fishies.py
@@ -5,15 +5,13 @@ import time
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
-from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Fishies(Base):
     def __init__(self, **kwargs):
         super(Fishies, self).__init__(**kwargs)
         self.pixels = []
-        # self.palette = color.get_random_palette(COLOR_MAXIMUM)
-        self.palette = color.get_palette('rainbow_bunny', COLOR_MAXIMUM)
+        self.palette = color.get_palette('rainbow_bunny')
         self.palette_length = len(self.palette)
         self.fishies = self.init_fishies()
         self.last_time = None

--- a/floor/floor/processor/hyperspace.py
+++ b/floor/floor/processor/hyperspace.py
@@ -5,7 +5,6 @@ import math
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
-from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Hyperspace(Base):
@@ -16,8 +15,7 @@ class Hyperspace(Base):
         super(Hyperspace, self).__init__(**kwargs)
         self.pixels = []
         self.times = [0 for _ in range(64)]
-        # self.palette = color.get_random_palette(COLOR_MAXIMUM)
-        self.palette = color.get_palette('rainbow_bunny', COLOR_MAXIMUM)
+        self.palette = color.get_palette('rainbow_bunny')
         self.palette_length = len(self.palette)
         self.radius_map_1 = [None] * 64
         self.radius_map_2 = [None] * 64

--- a/floor/floor/processor/kaleidoscope.py
+++ b/floor/floor/processor/kaleidoscope.py
@@ -4,7 +4,6 @@ import random
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 import floor.util.color_utils as color
-from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Kaleidoscope(Base):
@@ -15,7 +14,7 @@ class Kaleidoscope(Base):
         super(Kaleidoscope, self).__init__(**kwargs)
         self.active_px = []
         self.times = [0 for _ in range(64)]
-        self.palette = color.get_random_palette(COLOR_MAXIMUM)
+        self.palette = color.get_random_palette()
         self.palette_length = len(self.palette)
 
         for x in range(0, 64):

--- a/floor/floor/processor/land_mines.py
+++ b/floor/floor/processor/land_mines.py
@@ -16,7 +16,7 @@ class LandMines(Base):
         self.pixels = []
         self.mines = []
         self.walkers = self.init_walkers()
-        self.palette = color_utils.get_random_palette(COLOR_MAXIMUM)
+        self.palette = color_utils.get_random_palette()
         self.palette_length = len(self.palette)
         for x in range(0, 8):
             for y in range(0, 8):

--- a/floor/floor/processor/stripes.py
+++ b/floor/floor/processor/stripes.py
@@ -5,7 +5,6 @@ import random
 from floor.processor.base import Base
 from floor.processor.utils import clocked
 from floor.util import color_utils
-from floor.processor.constants import COLOR_MAXIMUM
 
 
 class Stripes(Base):
@@ -16,7 +15,7 @@ class Stripes(Base):
 
     def __init__(self, **kwargs):
         super(Stripes, self).__init__(**kwargs)
-        self.palette = color_utils.get_random_palette(COLOR_MAXIMUM)
+        self.palette = color_utils.get_random_palette()
         self.gradient = [[] for _ in range(len(self.palette))]
         self.stripes = [None for _ in range(8)]  # list[Stripe]
 

--- a/floor/floor/processor/throbber.py
+++ b/floor/floor/processor/throbber.py
@@ -1,11 +1,12 @@
 from builtins import range
 from floor.processor.base import Base
+from floor.util.color_utils import hex_to_rgb
 
 
-RED = (0xff, 0x00, 0x00)
-YELLOW = (0xff, 0xf0, 0x00)
-GREEN = (0x00, 0xff, 0x00)
-BLUE = (0x00, 0x00, 0xff)
+RED = hex_to_rgb('#ff0000')
+YELLOW = hex_to_rgb('#ffff00')
+GREEN = hex_to_rgb('#00ff00')
+BLUE = hex_to_rgb('#0000ff')
 
 COLORS = [RED, YELLOW, GREEN, BLUE]
 

--- a/floor/floor/processor/zap.py
+++ b/floor/floor/processor/zap.py
@@ -3,15 +3,7 @@ import collections
 
 from floor.processor.base import Base
 from floor.processor.utils import clocked
-
-
-def tint(color, percent):
-    """Lighten `color` to white by `percent`"""
-    r, g, b = color
-    new_r = r + (255 - r) * percent
-    new_g = g + (255 - g) * percent
-    new_b = b + (255 - b) * percent
-    return new_r, new_g, new_b
+from floor.util.color_utils import tint, hex_to_rgb
 
 
 def gradient(color, steps=4):
@@ -24,12 +16,12 @@ def gradient(color, steps=4):
     return ret
 
 
-RED = (0xff, 0x00, 0x00)
-ORANGE = (0xff, 0xa5, 0x00)
-GREEN = (0x00, 0xff, 0x00)
-YELLOW = (0xff, 0xff, 0x00)
-BLUE = (0, 0, 0xff)
-PURPLE = (0x94, 0x00, 0xd3)
+RED = hex_to_rgb('#ff0000')
+ORANGE = hex_to_rgb('#ffa500')
+GREEN = hex_to_rgb('#00ff00')
+YELLOW = hex_to_rgb('#ffff00')
+BLUE = hex_to_rgb('#0000ff')
+PURPLE = hex_to_rgb('#9400d3')
 
 COLOR_SETS = [
     gradient(RED),

--- a/floor/floor/util/color_utils_tests.py
+++ b/floor/floor/util/color_utils_tests.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from unittest import TestCase
 from . import color_utils
+from floor.processor.constants import BLACK, WHITE, COLOR_MAXIMUM
 
 
 class ColorUtilsTests(TestCase):
@@ -28,3 +29,24 @@ class ColorUtilsTests(TestCase):
 
         above = 0, 0, 255
         self.assertEqual((0, 0, 63), color_utils.alpha_blend(above, below, 0.25))
+
+    def test_tint(self):
+        red = (COLOR_MAXIMUM, 0, 0)
+        self.assertEqual(red, color_utils.tint(red, 0))
+        self.assertEqual(WHITE, color_utils.tint(red, 1))
+        self.assertEqual((COLOR_MAXIMUM, COLOR_MAXIMUM/2, COLOR_MAXIMUM/2), color_utils.tint(red, 0.5))
+
+    def test_shade(self):
+        red = (COLOR_MAXIMUM, 0, 0)
+        self.assertEqual(red, color_utils.shade(red, 0))
+        self.assertEqual(BLACK, color_utils.shade(red, 1))
+        self.assertEqual((512, 0, 0), color_utils.shade(red, 0.5))
+
+    def test_hex_to_rgb(self):
+        self.assertEqual(WHITE, color_utils.hex_to_rgb('#ffffff'))
+        self.assertEqual(BLACK, color_utils.hex_to_rgb('#000000'))
+        self.assertEqual((0, COLOR_MAXIMUM, 0), color_utils.hex_to_rgb('#00ff00'))
+
+    def test_get_pallet(self):
+        for p in color_utils.palettes.keys():
+            color_utils.get_palette(p)


### PR DESCRIPTION
I noticed Zap, Throbber, and Animator were outputting some dim patterns.
It looks like a bug I introduced when refactoring colors in #46.
The bug is these processors were defining colors on (0, 256) and
never rescaling them.

To fix this & hopefully avoid similar bugs in the future, updated
`hex_to_rgb` to return properly scaled colors; and deleted the scaling
from the `get_pallet` / `get_random_pallet` interfaces since there
were no callers that need to provide a different scale.

Moved some helper methods `tint()` and `shade()` into color utils
while I was in the area.