### PR TITLE
 Add support for RGBA pixels

### DIFF
--- a/floor/floor/controller/controller_test.py
+++ b/floor/floor/controller/controller_test.py
@@ -64,7 +64,7 @@ class ControllerTest(TestCase):
         controller = Controller(driver, playlist)
 
         controller.run_one_frame()
-        self.assertEqual([BLUE] * 64, driver.set_leds.call_args[0][0])
+        self.assertEqual([BLUE + (1.0,)] * 64, driver.set_leds.call_args[0][0])
 
         overlay2 = controller.layers['overlay2']
         overlay2.set_processor(red_processor)

--- a/floor/floor/util/color_utils.py
+++ b/floor/floor/util/color_utils.py
@@ -151,11 +151,16 @@ def get_random_palette():
 
 
 def normalize_pixel(pixel):
-    r, g, b = pixel
+    r, g, b = pixel[:3]
+    if len(pixel) == 4:
+        alpha = pixel[3]
+    else:
+        alpha = 1.0
     return (
         max(0, min(int(r), COLOR_MAXIMUM)),
         max(0, min(int(g), COLOR_MAXIMUM)),
         max(0, min(int(b), COLOR_MAXIMUM)),
+        alpha,
     )
 
 
@@ -177,21 +182,23 @@ def shade(color, percent):
 
 def alpha_blend(pixel_above, pixel_below, alpha, black_is_transparent=True):
     """Blends `pixel_above` onto `pixel_below` with given alpha."""
+    pixel_alpha = 1.0
+    if len(pixel_above) == 4:
+        pixel_alpha = pixel_above[3]
+    alpha = alpha * pixel_alpha
     if pixel_above == (0, 0, 0) and black_is_transparent:
         # We treat black pixels as fully transparent.
-        # TODO(mikey): If/when pixels are managed with a separate alpha channel,
-        # we can remove this hack.
         return pixel_below
     elif alpha == 1.0:
         return pixel_above
     elif alpha == 0.0:
         return pixel_below
     else:
-        rAbove, gAbove, bAbove = pixel_above
-        rBelow, gBelow, bBelow = pixel_below
+        rAbove, gAbove, bAbove = pixel_above[:3]
+        rBelow, gBelow, bBelow = pixel_below[:3]
 
         rOut = alpha * rAbove + (1 - alpha) * rBelow
         gOut = alpha * gAbove + (1 - alpha) * gBelow
         bOut = alpha * bAbove + (1 - alpha) * bBelow
 
-        return normalize_pixel((rOut, gOut, bOut))
+        return normalize_pixel((rOut, gOut, bOut))[:3]

--- a/floor/floor/util/color_utils_tests.py
+++ b/floor/floor/util/color_utils_tests.py
@@ -10,9 +10,10 @@ from floor.processor.constants import BLACK, WHITE, COLOR_MAXIMUM
 
 class ColorUtilsTests(TestCase):
     def test_normalize_pixel(self):
-        self.assertEqual((0, 0, 0), color_utils.normalize_pixel((0, 1e-14, 0.000001)))
-        self.assertEqual((0, 12, 340), color_utils.normalize_pixel((1e-14, 12, 340)))
-        self.assertEqual((0, 1024, 340), color_utils.normalize_pixel((1e-14, 99999, 340)))
+        self.assertEqual((0, 0, 0, 1.0), color_utils.normalize_pixel((0, 1e-14, 0.000001)))
+        self.assertEqual((0, 12, 340, 1.0), color_utils.normalize_pixel((1e-14, 12, 340)))
+        self.assertEqual((0, 1024, 340, 1.0), color_utils.normalize_pixel((1e-14, 99999, 340)))
+        self.assertEqual((0, 12, 340, 0.5), color_utils.normalize_pixel((1e-14, 12, 340, 0.5)))
 
     def test_alpha_blend(self):
         above = 255, 255, 255


### PR DESCRIPTION
Layer blending works as before, except will also factor in
the alpha value of the pixel, if it has one.

(Depends on #53 - only change here is 52b7676)