### PR TITLE
allow the controller to run and render even if playlist is stopped.

### DIFF
--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -135,11 +135,6 @@ class Controller(object):
 
     @profile(print_seconds=2)
     def run_one_frame(self):
-        if not self.playlist.is_running():
-            # If the playlist is stopped/paused, sleep a bit then restart the loop
-            self.clocksource.sleep(0.5)
-            return
-
         self.init_loop()
         self.generate_frame()
         self.transfer_data()

--- a/floor/floor/controller/rendering.py
+++ b/floor/floor/controller/rendering.py
@@ -115,6 +115,14 @@ class PlaylistRenderLayer(BaseRenderLayer):
         self.current_processor_args = None
         self.processor_render_layer = ProcessorRenderLayer()
 
+    def set_enabled(self, enabled):
+        """Suspend/unsuspend the playlist when the layer is enabled/disabled."""
+        super(PlaylistRenderLayer, self).set_enabled(enabled)
+        if self.enabled and not self.playlist.is_running():
+            self.playlist.start_playlist()
+        elif not self.enabled and self.playlist.is_running():
+            self.playlist.stop_playlist()
+
     def on_ranged_value_change(self, num, val):
         return self.processor_render_layer.on_ranged_value_change(num, val)
 
@@ -125,6 +133,8 @@ class PlaylistRenderLayer(BaseRenderLayer):
         return self.processor_render_layer.get_processor_name()
 
     def render(self, render_context):
+        if not self.playlist.is_running():
+            return None
         self._check_playlist(render_context)
         try:
             return self.processor_render_layer.render(render_context)

--- a/floor/floor/server/server.py
+++ b/floor/floor/server/server.py
@@ -90,20 +90,6 @@ def api_playlist():
     return jsonify(view_playlist(playlist))
 
 
-@app.route('/api/playlist/start', methods=['POST'])
-def api_playlist_start():
-    playlist = app.controller.playlist
-    playlist.start_playlist()
-    return jsonify(view_playlist(playlist))
-
-
-@app.route('/api/playlist/stop', methods=['POST'])
-def api_playlist_stop():
-    playlist = app.controller.playlist
-    playlist.stop_playlist()
-    return jsonify(view_playlist(playlist))
-
-
 @app.route('/api/playlist/advance', methods=['POST'])
 def api_playlist_advance():
     playlist = app.controller.playlist


### PR DESCRIPTION
As a side-effect, this removes the discrete playlist start/stop api.

Instead, the playlist's RenderLayer enabled/disabled state governs
whether the playlist is on (running/advancing and rendering) or off (not
advancing, and not rendering anything).

This allows us to run the floor in modes where we only utilize the
overlay layers.