### PR TITLE
Enhance playlist management, support uploading and switching playlists

### DIFF
--- a/floor/config/playlists/default.json
+++ b/floor/config/playlists/default.json
@@ -125,5 +125,6 @@
       "name": "Zap",
       "duration": "60"
     }
-  ]
+  ],
+  "title": "Default Playlist"
 }

--- a/floor/floor/controller/__init__.py
+++ b/floor/floor/controller/__init__.py
@@ -1,4 +1,4 @@
 from .controller import Controller
 from .test import Test
-from .playlist import Playlist
+from .playlist import Playlist, PlaylistManager
 from .layout import Layout

--- a/floor/floor/controller/controller.py
+++ b/floor/floor/controller/controller.py
@@ -13,6 +13,7 @@ from floor import processor
 from floor.processor.base import RenderContext
 from floor.controller.rendering import PlaylistRenderLayer
 from floor.controller.rendering import ProcessorRenderLayer
+from floor.controller.playlist import PlaylistManager
 from floor.util.color_utils import alpha_blend
 from floor.util.color_utils import normalize_pixel
 from floor.util.color_utils import set_brightness
@@ -26,12 +27,12 @@ class Controller(object):
     DEFAULT_FPS = 120
     DEFAULT_BPM = 120.0
 
-    def __init__(self, drivers, playlist, clocksource=time):
+    def __init__(self, drivers, playlist_manager, clocksource=time):
         """Constructor.
         
         Arguments:
             drivers {floor.driver.Base} -- One or more drivers for show output
-            playlist {floor.playlist.Playlist} -- The show's playlist
+            playlist_manager {floor.playlist.PlaylistManager} -- The show's playlist manager
         
         Keyword Arguments:
             clocksource {function} -- An object that should have `.time()`
@@ -39,7 +40,8 @@ class Controller(object):
         """
         assert len(drivers) > 0, 'Must provide 1 or more drivers'
         self.drivers = drivers
-        self.playlist = playlist
+        assert isinstance(playlist_manager, PlaylistManager), 'playlist_manager is not a PlaylistManager'
+        self.playlist_manager = playlist_manager
         self.clocksource = clocksource
         self.frame_start = 0
         self.fps = None
@@ -51,7 +53,7 @@ class Controller(object):
 
         # Ordered dict of layers to render, bottom-most layer first.
         self.layers = OrderedDict((
-            ('playlist', PlaylistRenderLayer(playlist=self.playlist, all_processors=self.all_processors)),
+            ('playlist', PlaylistRenderLayer(playlist_manager=self.playlist_manager, all_processors=self.all_processors)),
             ('overlay2', ProcessorRenderLayer()),
             ('overlay1', ProcessorRenderLayer()),
         ))

--- a/floor/floor/controller/controller_test.py
+++ b/floor/floor/controller/controller_test.py
@@ -41,7 +41,7 @@ class ControllerTest(TestCase):
 
     def setUp(self):
         all_procs = all_processors()
-        self.playlist = Playlist.from_file(all_procs, DEFAULT_PLAYLIST)
+        self.playlist = Playlist.from_file(DEFAULT_PLAYLIST, all_procs)
         self.playlist_manager = PlaylistManager(self.playlist)
         self.driver = Mock()
         self.driver = self.new_fake_driver()
@@ -95,7 +95,7 @@ class ControllerTest(TestCase):
         driver2 = Mock()
         driver2.get_weights = Mock(return_value=[0, 0, 0, 1] * 16)
 
-        playlist = Playlist.from_file(all_processors(), DEFAULT_PLAYLIST)
+        playlist = Playlist.from_file(DEFAULT_PLAYLIST, all_processors())
         playlist_manager = PlaylistManager(playlist)
         controller = Controller([driver1, driver2], playlist_manager)
         weights = controller.get_weights()

--- a/floor/floor/controller/controller_test.py
+++ b/floor/floor/controller/controller_test.py
@@ -59,14 +59,14 @@ class ControllerTest(TestCase):
         self.driver.read_data.assert_called_once()
         self.driver.send_data.assert_called_once()
 
-        first_processor_name = self.playlist.queue[0]['name']
-        self.assertEqual(first_processor_name, c.layers['playlist'].current_processor.__class__.__name__)
+        first_processor_class = self.playlist.queue[0].processor_cls
+        self.assertEqual(first_processor_class, c.layers['playlist'].current_processor.__class__)
 
     def test_layer_blending(self):
         red_processor = SingleColorProcessor(color=RED)
         green_processor = SingleColorProcessor(color=GREEN)
         
-        playlist = Playlist.from_single_processor(SingleColorProcessor(), args={'color': BLUE})
+        playlist = Playlist.from_single_processor(SingleColorProcessor, args={'color': BLUE})
         driver = self.new_fake_driver()
         controller = Controller([driver], playlist)
 

--- a/floor/floor/controller/midi/functions.py
+++ b/floor/floor/controller/midi/functions.py
@@ -27,67 +27,67 @@ class MidiFunctions(object):
 
 
 MidiFunctions.add('playlist_next',
-                  callback=lambda controller, _: controller.playlist.advance(),
+                  callback=lambda controller, _: controller.playlist_manager.advance(),
                   help_text='Advance to the next item in the current playlist.')
 MidiFunctions.add('playlist_previous',
-                  callback=lambda controller, _: controller.playlist.previous(),
+                  callback=lambda controller, _: controller.playlist_manager.previous(),
                   help_text='Go to previous item in the current playlist.')
 MidiFunctions.add('playlist_play',
-                  callback=lambda controller, _: controller.playlist.start_playlist(),
+                  callback=lambda controller, _: controller.playlist_manager.start_playlist(),
                   help_text='Play the current playlist.')
 MidiFunctions.add('playlist_stay',
-                  callback=lambda controller, _: controller.playlist.stay(),
+                  callback=lambda controller, _: controller.playlist_manager.stay(),
                   help_text='Loop/repeat the current item in the playlist.')
 MidiFunctions.add('playlist_stop',
-                  callback=lambda controller, _: controller.playlist.stop_playlist(),
+                  callback=lambda controller, _: controller.playlist_manager.stop_playlist(),
                   help_text='Stop playback of the current playlist.')
 MidiFunctions.add('playlist_goto_1',
-                  callback=lambda controller, _: controller.playlist.go_to(1),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(1),
                   help_text='Go to playlist position 1.')
 MidiFunctions.add('playlist_goto_2',
-                  callback=lambda controller, _: controller.playlist.go_to(2),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(2),
                   help_text='Go to playlist position 2.')
 MidiFunctions.add('playlist_goto_3',
-                  callback=lambda controller, _: controller.playlist.go_to(3),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(3),
                   help_text='Go to playlist position 3.')
 MidiFunctions.add('playlist_goto_4',
-                  callback=lambda controller, _: controller.playlist.go_to(4),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(4),
                   help_text='Go to playlist position 4.')
 MidiFunctions.add('playlist_goto_5',
-                  callback=lambda controller, _: controller.playlist.go_to(5),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(5),
                   help_text='Go to playlist position 5.')
 MidiFunctions.add('playlist_goto_6',
-                  callback=lambda controller, _: controller.playlist.go_to(6),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(6),
                   help_text='Go to playlist position 6.')
 MidiFunctions.add('playlist_goto_7',
-                  callback=lambda controller, _: controller.playlist.go_to(7),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(7),
                   help_text='Go to playlist position 7.')
 MidiFunctions.add('playlist_goto_8',
-                  callback=lambda controller, _: controller.playlist.go_to(8),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(8),
                   help_text='Go to playlist position 8.')
 MidiFunctions.add('playlist_goto_9',
-                  callback=lambda controller, _: controller.playlist.go_to(9),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(9),
                   help_text='Go to playlist position 9.')
 MidiFunctions.add('playlist_goto_10',
-                  callback=lambda controller, _: controller.playlist.go_to(10),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(10),
                   help_text='Go to playlist position 10.')
 MidiFunctions.add('playlist_goto_11',
-                  callback=lambda controller, _: controller.playlist.go_to(11),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(11),
                   help_text='Go to playlist position 11.')
 MidiFunctions.add('playlist_goto_12',
-                  callback=lambda controller, _: controller.playlist.go_to(12),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(12),
                   help_text='Go to playlist position 12.')
 MidiFunctions.add('playlist_goto_13',
-                  callback=lambda controller, _: controller.playlist.go_to(13),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(13),
                   help_text='Go to playlist position 13.')
 MidiFunctions.add('playlist_goto_14',
-                  callback=lambda controller, _: controller.playlist.go_to(14),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(14),
                   help_text='Go to playlist position 14.')
 MidiFunctions.add('playlist_goto_15',
-                  callback=lambda controller, _: controller.playlist.go_to(15),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(15),
                   help_text='Go to playlist position 15.')
 MidiFunctions.add('playlist_goto_16',
-                  callback=lambda controller, _: controller.playlist.go_to(16),
+                  callback=lambda controller, _: controller.playlist_manager.go_to(16),
                   help_text='Go to playlist position 16.')
 MidiFunctions.add('set_bpm',
                   callback=lambda controller, value: controller.set_bpm(90 + 80 * (value / 127.0)),

--- a/floor/floor/controller/midi_test.py
+++ b/floor/floor/controller/midi_test.py
@@ -81,19 +81,19 @@ class MidiManagerTestCase(TestCase):
         handler.on_midi_commands(peer, [command])
 
     def test_midi_passthru(self):
-        self.assertEqual(0, self.controller.playlist.advance.call_count)
+        self.assertEqual(0, self.controller.playlist_manager.advance.call_count)
         self.inject_note_on('C3', 127)
-        self.assertEqual(1, self.controller.playlist.advance.call_count)
+        self.assertEqual(1, self.controller.playlist_manager.advance.call_count)
 
-        self.assertEqual(0, self.controller.playlist.previous.call_count)
+        self.assertEqual(0, self.controller.playlist_manager.previous.call_count)
         self.inject_note_on('C4', 55)
-        self.assertEqual(1, self.controller.playlist.previous.call_count)
+        self.assertEqual(1, self.controller.playlist_manager.previous.call_count)
 
-        self.assertEqual(0, self.controller.playlist.stop_playlist.call_count)
+        self.assertEqual(0, self.controller.playlist_manager.stop_playlist.call_count)
         self.inject_control_mode_change(21, 11)
-        self.assertEqual(0, self.controller.playlist.stop_playlist.call_count)
+        self.assertEqual(0, self.controller.playlist_manager.stop_playlist.call_count)
         self.inject_control_mode_change(21, 127)
-        self.assertEqual(1, self.controller.playlist.stop_playlist.call_count)
+        self.assertEqual(1, self.controller.playlist_manager.stop_playlist.call_count)
 
         self.assertEqual(0, self.controller.handle_input_event.call_count)
         self.inject_control_mode_change(48, 99)
@@ -110,6 +110,6 @@ class MidiManagerTestCase(TestCase):
         ])
 
     def test_note_name_translation(self):
-        self.assertEqual(0, self.controller.playlist.stay.call_count)
+        self.assertEqual(0, self.controller.playlist_manager.stay.call_count)
         self.inject_note_on('Csn1', 127)
-        self.assertEqual(1, self.controller.playlist.stay.call_count)
+        self.assertEqual(1, self.controller.playlist_manager.stay.call_count)

--- a/floor/floor/controller/playlist.py
+++ b/floor/floor/controller/playlist.py
@@ -3,6 +3,8 @@ import json
 from time import time
 import logging
 from floor.processor.base import Base as ProcessorBase
+import os
+import re
 
 logger = logging.getLogger('playlist')
 
@@ -45,7 +47,8 @@ class PlaylistItem:
 
 
 class Playlist(object):
-    def __init__(self):
+    def __init__(self, title):
+        self.title = title
         # The index into the queue array
         self.position = None
         # Time when the playlist should auto advance.
@@ -55,13 +58,13 @@ class Playlist(object):
 
     @classmethod
     def from_file(cls, all_processors, filename, strict=False):
-        playlist = cls()
+        playlist = cls('Playlist')
         playlist.load_from(filename, all_processors, strict=strict)
         return playlist
 
     @classmethod
     def from_single_processor(cls, processor_cls, args=None):
-        playlist = cls()
+        playlist = cls('Playlist')
         playlist.append(PlaylistItem(processor_cls, processor_args=args))
         return playlist
 
@@ -91,7 +94,8 @@ class Playlist(object):
 
     def save_to(self, output_filename):
         playlist = {
-            "queue": self.queue,
+            'queue': self.queue,
+            'title': self.title,
         }
         with open(output_filename, 'w') as fp:
             fp.write(json.dumps(playlist, indent=2))
@@ -205,3 +209,99 @@ class Playlist(object):
 
     def stay(self):
         self.next_advance = None
+
+
+class PlaylistManager:
+    PLAYLIST_NAME_DEFAULT = 'default'
+    PLAYLIST_NAME_RE = re.compile('[0-9a-zA-Z_\s]+')
+
+    def __init__(self, default_playlist, user_playlists_dir=None):
+        self.default_playlist = default_playlist
+        self.user_playlists_dir = user_playlists_dir
+        self.user_playlists = {}
+        self.current_playlist = self.default_playlist
+        self.logger = logging.getLogger('PlaylistManager')
+
+    def initialize(self, all_processors):
+        """Load all uer playlists into memory."""
+        if not self.user_playlists_dir or not os.path.isdir(self.user_playlists_dir):
+            return
+        all_playlists = os.listdir(self.user_playlists_dir)
+        for filename in all_playlists:
+            if not filename.endswith('.json'):
+                continue
+            full_path = os.path.join(self.user_playlists_dir, filename)
+            self._load_playlist_from_file(full_path, all_processors)
+
+    def _load_playlist_from_file(self, filename, all_processors):
+        base_name = os.path.basename(filename)
+        playlist_name = os.path.splitext(base_name)[0].lower()
+        playlist = Playlist(playlist_name)
+        playlist.load_from(filename, all_processors)
+        self.user_playlists[playlist_name] = playlist
+        self.logger.info('Loaded playlist "{}"'.format(playlist_name))
+        return playlist_name, playlist
+
+    def get_playlist(self, name):
+        if name == self.PLAYLIST_NAME_DEFAULT:
+            return self.default_playlist
+        return self.user_playlists.get(name)
+
+    def save_playlist(self, name):
+        name = name.lower()
+        if not self.PLAYLIST_NAME_RE.match(name):
+            raise ValueError('Illegal playlist name: "{}"'.format(name))
+
+        if name == self.PLAYLIST_NAME_DEFAULT:
+            self.logger.warning('save_playlist: saving the default playlist is not allowed.')
+            return
+
+        playlist = self.user_playlists.get(name)
+        if not playlist:
+            self.logger.warning('save_playlist: playlist "{}" not found'.format(name))
+            return
+
+        output_filename = os.path.join(self.user_playlists_dir, '{}.json'.format(name))
+        playlist.save_to(output_filename)
+
+    def get_current_playlist(self):
+        return self.current_playlist
+
+    def get_all_playlists(self):
+        result = {
+            'default': self.default_playlist,
+        }
+        result.update(self.user_playlists)
+        return result
+
+    def set_current_playlist(self, name):
+        if name is self.PLAYLIST_NAME_DEFAULT:
+            self.current_playlist = self.default_playlist
+        elif name in self.user_playlists:
+            self.current_playlist = self.user_playlists[name]
+        else:
+            self.logger.warning('set_current_playlist: Unknown playlist: "{}"'.format(name))
+
+    def advance(self):
+        """Convenience proxy for self.get_current_playlist().advance()"""
+        return self.current_playlist.advance()
+
+    def previous(self):
+        """Convenience proxy for self.get_current_playlist().previous()"""
+        return self.current_playlist.previous()
+
+    def start_playlist(self):
+        """Convenience proxy for self.get_current_playlist().start_playlist()"""
+        return self.current_playlist.start_playlist()
+
+    def stay(self):
+        """Convenience proxy for self.get_current_playlist().stay()"""
+        return self.current_playlist.stay()
+
+    def stop_playlist(self):
+        """Convenience proxy for self.get_current_playlist().stop_playlist()"""
+        return self.current_playlist.stop_playlist()
+
+    def go_to(self, position):
+        """Convenience proxy for self.get_current_playlist().go_to(position)"""
+        return self.current_playlist.go_to(position)

--- a/floor/floor/controller/playlist_test.py
+++ b/floor/floor/controller/playlist_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-from floor.controller.playlist import Playlist
+from floor.controller.playlist import Playlist, PlaylistItem
 from floor.controller.playlist import ProcessorNotFound
 from floor.processor import all_processors
 from unittest import TestCase
@@ -21,11 +21,36 @@ class PlaylistTest(TestCase):
         p = Playlist.from_file(self.all_procs, DEFAULT_PLAYLIST, strict=True)
         self.assert_(len(p.queue) > 0, 'Expected non-zero default playlist.')
 
-        all_procs = all_processors()
-        for processor in p.queue:
-            name = processor['name']
-            if name not in all_procs:
-                self.fail('Default playlist defines unknown processor "{}"'.format(name))
+    def test_playlist_item_from_and_to_object(self):
+        item = PlaylistItem.from_object({
+            'name': 'Animator',
+        }, self.all_procs)
 
+        item_object = item.to_object()
+        self.assertEqual({
+            'name': 'Animator',
+            'title': 'Animator',
+            'args': {},
+            'duration': None,
+        }, item_object)
+
+        item = PlaylistItem.from_object({
+            'name': 'Animator',
+            'title': 'My Other Animator',
+            'args': {'foo': 'bar'},
+            'duration': 123,
+        }, self.all_procs)
+
+        item_object = item.to_object()
+        self.assertEqual({
+            'name': 'Animator',
+            'title': 'My Other Animator',
+            'args': {'foo': 'bar'},
+            'duration': 123,
+        }, item_object)
+
+    def test_playlist_item_invalid_processor_name(self):
         with self.assertRaises(ProcessorNotFound):
-            p.append('ZoopZap')
+            PlaylistItem.from_object({
+                'name': 'ZoopZap',
+            }, self.all_procs)

--- a/floor/floor/controller/playlist_test.py
+++ b/floor/floor/controller/playlist_test.py
@@ -18,7 +18,7 @@ class PlaylistTest(TestCase):
         self.all_procs = all_processors()
 
     def test_default_playlist(self):
-        p = Playlist.from_file(self.all_procs, DEFAULT_PLAYLIST, strict=True)
+        p = Playlist.from_file(DEFAULT_PLAYLIST, self.all_procs, strict=True)
         self.assert_(len(p.queue) > 0, 'Expected non-zero default playlist.')
 
     def test_playlist_item_from_and_to_object(self):

--- a/floor/floor/server/README.md
+++ b/floor/floor/server/README.md
@@ -14,6 +14,10 @@ This is a simple HTTP service that exposes a public API and control web page to 
   - [`POST /api/playlist/add`](#post-apiplaylistadd)
   - [`POST /api/playlist/stay`](#post-apiplayliststay)
   - [`DELETE /api/playlist/:position`](#delete-apiplaylistposition)
+  - [`GET /api/playlists`](#get-apiplaylists)
+  - [`GET /api/playlists/:name`](#get-apiplaylistsname)
+  - [`POST /api/playlists/:name`](#post-apiplaylistsname)
+  - [`POST /api/playlists/:name/activate`](#post-apiplaylistsnameactivate)
   - [`GET /api/tempo`](#get-apitempo)
   - [`POST /api/tempo`](#post-apitempo)
   - [`POST /api/tempo/nudge`](#post-apitemponudge)
@@ -234,6 +238,58 @@ None.
 **Response**
 
 The playlist object upon success; HTTP `400` on error.
+
+
+### `GET /api/playlists`
+
+Lists _all_ playlists known to the system.
+
+**Request arguments**
+
+None.
+
+**Response**
+
+A dictionary of playlist items, keyed by a slug-like playlist name. Each value has the same format as `GET /api/playlist`.
+
+
+### `GET /api/playlists/:name`
+
+Fetches a single playlist, by slug-like playlist name.
+
+**Request arguments**
+
+None.
+
+**Response**
+
+The playlist object upon success; HTTP `404` if not found.
+
+
+### `POST /api/playlists/:name`
+
+Creates or updates a single playlist, by slug-like playlist name.
+
+**Request arguments**
+
+The request body should be a well-formed playlist object.
+
+**Response**
+
+The playlist object upon success; HTTP `400` upon failure.
+
+
+### `POST /api/playlists/:name/activate`
+
+Set this playlist as the current playlist.
+
+**Request arguments**
+
+None.
+
+**Response**
+
+The playlist object upon success; HTTP `404` if not found.
 
 
 ### `GET /api/tempo`

--- a/floor/floor/server/server.py
+++ b/floor/floor/server/server.py
@@ -62,7 +62,7 @@ def view_all_layers(layers):
 @app.route('/api/status', methods=['GET'])
 def api_status():
     result = {
-        'playlist': view_playlist(app.controller.playlist),
+        'playlist': view_playlist(app.controller.playlist_manager.get_current_playlist()),
         'tempo': view_tempo(app.controller.bpm, app.controller.downbeat),
         'processors': view_processors(app.controller.all_processors),
         'layers': view_all_layers(app.controller.layers),
@@ -73,20 +73,20 @@ def api_status():
 
 @app.route('/api/playlist', methods=['GET'])
 def api_playlist():
-    playlist = app.controller.playlist
+    playlist = app.controller.playlist_manager.get_current_playlist()
     return jsonify(view_playlist(playlist))
 
 
 @app.route('/api/playlist/advance', methods=['POST'])
 def api_playlist_advance():
-    playlist = app.controller.playlist
+    playlist = app.controller.playlist_manager.get_current_playlist()
     playlist.advance()
     return jsonify(view_playlist(playlist))
 
 
 @app.route('/api/playlist/previous', methods=['POST'])
 def api_playlist_previous():
-    playlist = app.controller.playlist
+    playlist = app.controller.playlist_manager.get_current_playlist()
     playlist.previous()
     return jsonify(view_playlist(playlist))
 
@@ -109,7 +109,7 @@ def api_playlist_add():
         abort(400, 'Processor "{}" not found'.format(name))
     item = PlaylistItem(processor, title=title, duration=duration, processor_args=args)
 
-    playlist = app.controller.playlist
+    playlist = app.controller.playlist_manager.get_current_playlist()
     try:
         if play_next:
             position = playlist.append(item)
@@ -127,14 +127,14 @@ def api_playlist_add():
 
 @app.route('/api/playlist/stay', methods=['POST'])
 def api_playlist_stay():
-    playlist = app.controller.playlist
-    app.controller.playlist.stay()
+    playlist = app.controller.playlist_manager.get_current_playlist()
+    app.controller.playlist_manager.get_current_playlist().stay()
     return jsonify(view_playlist(playlist))
 
 
 @app.route('/api/playlist/<int:position>', methods=['GET', 'DELETE'])
 def api_playlist_position(position):
-    playlist = app.controller.playlist
+    playlist = app.controller.playlist_manager.get_current_playlist()
     if request.method == 'DELETE':
         try:
             playlist.remove(position)

--- a/floor/run-show.py
+++ b/floor/run-show.py
@@ -140,11 +140,9 @@ def main():
             logger.error('Processor "{}" unknown'.format(args.processor_name))
             sys.exit(1)
     elif args.playlist:
-        playlist = Playlist('Default')
-        playlist.load_from(args.playlist, all_processors())
+        playlist = Playlist.from_file(args.playlist, all_processors())
     else:
-        playlist = Playlist('Default')
-        playlist.load_from(DEFAULT_PLAYLIST, all_processors())
+        playlist = Playlist.from_file(DEFAULT_PLAYLIST, all_processors())
 
     playlist_manager = PlaylistManager(playlist, user_playlists_dir=args.user_playlists_dir)
     show = Controller(drivers, playlist_manager)

--- a/floor/run-show.py
+++ b/floor/run-show.py
@@ -126,17 +126,18 @@ def main():
         logger.error('Cannot provide both --playlist and --processor')
         sys.exit(1)
 
-    playlist = Playlist(all_processors())
     if args.processor_name:
         try:
-            playlist.append(args.processor_name)
+            playlist = Playlist.from_object({'name': args.processor_name})
         except ProcessorNotFound:
             logger.error('Processor "{}" unknown'.format(args.processor_name))
             sys.exit(1)
     elif args.playlist:
-        playlist.load_from(args.playlist)
+        playlist = Playlist()
+        playlist.load_from(args.playlist, all_processors())
     else:
-        playlist.load_from(DEFAULT_PLAYLIST)
+        playlist = Playlist()
+        playlist.load_from(DEFAULT_PLAYLIST, all_processors())
 
     show = Controller(drivers, playlist)
 


### PR DESCRIPTION
This change introduces the concept of `PlaylistManager`; updates `Controller` to use one (rather than a single `Playlist`); and adds API support and some under-the-hood refactors along the way.

The goal is to support multiple playlists during a show, and the ability to easily switch among them. The concept of the "default" playlist is retained.

Outside of the default playlist, new playlists can be uploaded through the API when the `--user_playlists_dir` flag is set. Currently the flag default to the `floor/config/playlists/` dir, i.e., the feature is default-enabled.

(Depends on #63)

Closes #25 - I think!